### PR TITLE
Improve performance of Solis Modbus sensor

### DIFF
--- a/custom_components/solis_modbus/const.py
+++ b/custom_components/solis_modbus/const.py
@@ -1,6 +1,6 @@
 DOMAIN = "solis_modbus"
 CONTROLLER = "modbus_controller"
-VERSION = "1.3.1"
+VERSION = "1.3.2"
 POLL_INTERVAL_SECONDS = 5
 MANUFACTURER = "Solis"
 MODEL = "S6"

--- a/custom_components/solis_modbus/const.py
+++ b/custom_components/solis_modbus/const.py
@@ -1,6 +1,6 @@
 DOMAIN = "solis_modbus"
 CONTROLLER = "modbus_controller"
 VERSION = "1.3.2"
-POLL_INTERVAL_SECONDS = 5
+POLL_INTERVAL_SECONDS = 15
 MANUFACTURER = "Solis"
 MODEL = "S6"

--- a/custom_components/solis_modbus/manifest.json
+++ b/custom_components/solis_modbus/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/Pho3niX90/solis_modbus/issues",
   "quality_scale": "silver",
   "requirements": ["pymodbus==3.5.4"],
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/custom_components/solis_modbus/sensor.py
+++ b/custom_components/solis_modbus/sensor.py
@@ -25,7 +25,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     sensor_entities: List[SensorEntity] = []
     sensor_derived_entities: List[SensorEntity] = []
     hass.data[DOMAIN]['values'] = {}
-    hass.data[DOMAIN]['POLL_COUNTER'] = 0
 
     sensors = [
         {
@@ -579,7 +578,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         },
     ]
 
-
     sensors_derived = [
         {"type": "SDS", "name": "Solis Status String",
          "unique": "solis_modbus_inverter_current_status_string", "multiplier": 0,
@@ -635,7 +633,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
 
         for sensor_group in sensors:
             start_register = sensor_group['register_start']
-            scan_interval = sensor_group['scan_interval']
 
             count = sum(len(entity.get('register', [])) for entity in sensor_group.get('entities', []))
 
@@ -655,11 +652,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         for entity in hass.data[DOMAIN]["sensor_derived_entities"]:
             entity.update()
 
-    hass.data[DOMAIN]['POLL_COUNTER'] += 1
-
-    # Schedule the update function to run every X seconds
     async_track_time_interval(hass, async_update, timedelta(seconds=POLL_INTERVAL_SECONDS))
-
     return True
 
 

--- a/custom_components/solis_modbus/time.py
+++ b/custom_components/solis_modbus/time.py
@@ -119,6 +119,7 @@ class SolisTimeEntity(TimeEntity):
         _LOGGER.debug(f'Update time entity with hour = {hour}, minute = {minute}')
 
         self._attr_native_value = time(hour=hour, minute=minute)
+        # self.async_write_ha_state()
 
     @property
     def device_info(self):
@@ -136,10 +137,10 @@ class SolisTimeEntity(TimeEntity):
         if self._attr_native_value == value:
             return
         _LOGGER.debug(f'set_native_value : register = {self._register}, value = {value}')
-        self._attr_native_value = value
-        self.schedule_update_ha_state()
 
     async def async_set_value(self, value: time) -> None:
         """Set the time."""
         _LOGGER.debug(f'async_set_value : register = {self._register}, value = {value}')
         self._modbus_controller.write_holding_registers(self._register, [value.hour, value.minute])
+        self._attr_native_value = value
+        self.async_write_ha_state()


### PR DESCRIPTION
Removed unnecessary polling counter and scan interval in the Solis Modbus sensor. Also rearranged the order of operations in the time setting process to further optimize the code. The async write operation for the home automation state is now executed immediately after setting the time value. fixes #28