### PR TITLE
Refactor async_update to use asyncio

### DIFF
--- a/custom_components/solis_modbus/const.py
+++ b/custom_components/solis_modbus/const.py
@@ -1,6 +1,6 @@
 DOMAIN = "solis_modbus"
 CONTROLLER = "modbus_controller"
-VERSION = "1.3.5"
+VERSION = "1.4.0"
 POLL_INTERVAL_SECONDS = 15
 MANUFACTURER = "Solis"
 MODEL = "S6"

--- a/custom_components/solis_modbus/manifest.json
+++ b/custom_components/solis_modbus/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/Pho3niX90/solis_modbus/issues",
   "quality_scale": "silver",
   "requirements": ["pymodbus==3.5.4"],
-  "version": "1.3.5"
+  "version": "1.4.0"
 }

--- a/custom_components/solis_modbus/sensor.py
+++ b/custom_components/solis_modbus/sensor.py
@@ -753,14 +753,15 @@ def clock_drift_test(hours, minutes, seconds):
     d_hours = r_hours - hours
     d_minutes = r_minutes - minutes
     d_seconds = r_seconds - seconds
+    total_drift = (d_hours * 60 * 60) + (d_minutes * 60) + d_seconds
 
-    if abs(d_seconds) > 60:
+    if abs(total_drift) > 60:
         _LOGGER.critical(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
 
-    elif abs(d_seconds) > 30:
+    elif abs(total_drift) > 30:
         _LOGGER.warning(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
 
-    elif abs(d_seconds) > 10:
+    elif abs(total_drift) > 10:
         _LOGGER.info(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
     else:
         _LOGGER.debug(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")

--- a/custom_components/solis_modbus/sensor.py
+++ b/custom_components/solis_modbus/sensor.py
@@ -757,11 +757,13 @@ def clock_drift_test(hours, minutes, seconds):
     if abs(d_seconds) > 60:
         _LOGGER.critical(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
 
-    if abs(d_seconds) > 30:
+    elif abs(d_seconds) > 30:
         _LOGGER.warning(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
 
-    if abs(d_seconds) > 10:
+    elif abs(d_seconds) > 10:
         _LOGGER.info(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
+    else:
+        _LOGGER.debug(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
 
 
 class SolisDerivedSensor(RestoreSensor, SensorEntity):

--- a/custom_components/solis_modbus/sensor.py
+++ b/custom_components/solis_modbus/sensor.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import timedelta, datetime
 from typing import List
 
 from homeassistant.components.sensor import SensorEntity, RestoreSensor
@@ -184,7 +184,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
 
                 {"type": "SS", "name": "Solis Active Power",
                  "unique": "solis_modbus_inverter_active_power",
-                 "register": ['33079', '33080'], "device_class": SensorDeviceClass.POWER, "multiplier": 0.001,
+                 "register": ['33079', '33080'], "device_class": SensorDeviceClass.POWER, "multiplier": 1,
                  "unit_of_measurement": UnitOfPower.WATT, "state_class": SensorStateClass.MEASUREMENT},
 
                 {"type": "SS", "name": "Solis Reactive Power",
@@ -213,7 +213,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                 {"type": "SS", "name": "Solis Status", "unique": "solis_modbus_inverter_current_status",
                  "register": ['33095'], "multiplier": 0, "state_class": SensorStateClass.MEASUREMENT},
 
-                {"type": "SS", "name": "Solis Lead-acid Battery Temperature", "unique": "solis_modbus_inverter_lead_acid_temp",
+                {"type": "SS", "name": "Solis Lead-acid Battery Temperature",
+                 "unique": "solis_modbus_inverter_lead_acid_temp",
                  "register": ['33096'], "device_class": SensorDeviceClass.TEMPERATURE, "multiplier": 0.1,
                  "unit_of_measurement": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT},
             ]
@@ -226,11 +227,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                  "unique": "solis_modbus_inverter_storage_control_switching_value", "register": ['33132'],
                  "multiplier": 0, "state_class": SensorStateClass.MEASUREMENT},
                 {"type": "SS", "name": "Solis Battery Voltage",
-                 "unique": "solis_modbus_inverter_battery_voltage", "register": ['33133'], "device_class": SensorDeviceClass.VOLTAGE,
-                 "multiplier": 0.1, "unit_of_measurement": UnitOfElectricPotential.VOLT, "state_class": SensorStateClass.MEASUREMENT},
+                 "unique": "solis_modbus_inverter_battery_voltage", "register": ['33133'],
+                 "device_class": SensorDeviceClass.VOLTAGE,
+                 "multiplier": 0.1, "unit_of_measurement": UnitOfElectricPotential.VOLT,
+                 "state_class": SensorStateClass.MEASUREMENT},
                 {"type": "SS", "name": "Solis Battery Current",
-                 "unique": "solis_modbus_inverter_battery_current", "register": ['33134'], "device_class": SensorDeviceClass.CURRENT,
-                 "multiplier": 0.1, "unit_of_measurement": UnitOfElectricCurrent.AMPERE, "state_class": SensorStateClass.MEASUREMENT},
+                 "unique": "solis_modbus_inverter_battery_current", "register": ['33134'],
+                 "device_class": SensorDeviceClass.CURRENT,
+                 "multiplier": 0.1, "unit_of_measurement": UnitOfElectricCurrent.AMPERE,
+                 "state_class": SensorStateClass.MEASUREMENT},
                 {"type": "SS", "name": "Solis Battery Current Direction",
                  "unique": "solis_modbus_inverter_battery_current_direction",
                  "register": ['33135'],
@@ -489,7 +494,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                 {"type": "reserve", "register": ['43025', '43026']},
                 {"type": "SS", "name": "Solis Battery Force-charge Power Limitation",
                  "unique": "solis_modbus_inverter_battery_force_charge_limit",
-                 "register": ['43027'], "device_class": SensorDeviceClass.POWER, "multiplier": 0, "display_multiplier": 10,
+                 "register": ['43027'], "device_class": SensorDeviceClass.POWER, "multiplier": 0,
+                 "display_multiplier": 10,
                  "unit_of_measurement": UnitOfPower.WATT, "state_class": SensorStateClass.MEASUREMENT},
                 {"type": "SS", "name": "Solis Battery Force Charge Source",
                  "unique": "solis_modbus_inverter_battery_force_charge_source", "register": ['43028'], "multiplier": 0,
@@ -538,7 +544,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                  "multiplier": 0, "unit_of_measurement": UnitOfTime.HOURS, "state_class": SensorStateClass.MEASUREMENT},
                 {"type": "SS", "name": "Solis Time-Charging Discharge End Minute (Slot 1)",
                  "unique": "solis_modbus_inverter_time_discharge_end_minute_slot1", "register": ['43150'],
-                 "multiplier": 0, "unit_of_measurement": UnitOfTime.MINUTES, "state_class": SensorStateClass.MEASUREMENT},
+                 "multiplier": 0, "unit_of_measurement": UnitOfTime.MINUTES,
+                 "state_class": SensorStateClass.MEASUREMENT},
 
                 {"type": "reserve", "register": ['43051', '43052', '43052']},
 
@@ -547,7 +554,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                  "multiplier": 0, "unit_of_measurement": UnitOfTime.HOURS, "state_class": SensorStateClass.MEASUREMENT},
                 {"type": "SS", "name": "Solis Time-Charging Charge Start Minute (Slot 2)",
                  "unique": "solis_modbus_inverter_time_charging_start_minute_slot2", "register": ['43154'],
-                 "multiplier": 0, "unit_of_measurement": UnitOfTime.MINUTES, "state_class": SensorStateClass.MEASUREMENT},
+                 "multiplier": 0, "unit_of_measurement": UnitOfTime.MINUTES,
+                 "state_class": SensorStateClass.MEASUREMENT},
                 {"type": "SS", "name": "Solis Time-Charging Charge End Hour (Slot 2)",
                  "unique": "solis_modbus_inverter_time_charging_end_hour_slot2", "register": ['43155'], "multiplier": 0,
                  "unit_of_measurement": UnitOfTime.HOURS, "state_class": SensorStateClass.MEASUREMENT},
@@ -734,6 +742,28 @@ def extract_serial_number(values):
     return ''.join([hex_to_ascii(hex_value) for hex_value in values])
 
 
+def clock_drift_test(hours, minutes, seconds):
+    # Get the current time
+    current_time = datetime.now()
+
+    # Extract hours, minutes, and seconds
+    r_hours = current_time.hour
+    r_minutes = current_time.minute
+    r_seconds = current_time.second
+    d_hours = r_hours - hours
+    d_minutes = r_minutes - minutes
+    d_seconds = r_seconds - seconds
+
+    if abs(d_seconds) > 60:
+        _LOGGER.critical(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
+
+    if abs(d_seconds) > 30:
+        _LOGGER.warning(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
+
+    if abs(d_seconds) > 10:
+        _LOGGER.info(f"inverter time {hours}:{minutes}:{seconds}. drift = {d_hours}:{d_minutes}:{d_seconds}")
+
+
 class SolisDerivedSensor(RestoreSensor, SensorEntity):
     """Representation of a Modbus derived/calculated sensor."""
 
@@ -778,13 +808,16 @@ class SolisDerivedSensor(RestoreSensor, SensorEntity):
                 return
 
             n_value = None
+
             if '33095' in self._register:
                 n_value = round(get_value(self))
                 n_value = STATUS_MAPPING.get(n_value, "Unknown")
+
             if '33049' in self._register or '33051' in self._register:
                 r1_value = self._hass.data[DOMAIN]['values'][self._register[0]] * self._multiplier
                 r2_value = self._hass.data[DOMAIN]['values'][self._register[1]] * self._multiplier
                 n_value = round(r1_value * r2_value)
+
             if '33135' in self._register and len(self._register) == 4:
                 registers = self._register.copy()
                 self._register = registers[:2]
@@ -855,7 +888,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         state = await self.async_get_last_sensor_data()
-        if state:
+        if state and state.native_value is not None:
             self._attr_native_value = state.native_value * self._display_multiplier
         self.is_added_to_hass = True
 
@@ -864,6 +897,12 @@ class SolisSensor(RestoreSensor, SensorEntity):
         try:
             if not self.is_added_to_hass:
                 return
+
+            if '33027' in self._register:
+                hours = self._hass.data[DOMAIN]['values'][str(int(self._register[0]) - 2)]
+                minutes = self._hass.data[DOMAIN]['values'][str(int(self._register[0]) - 1)]
+                seconds = self._hass.data[DOMAIN]['values'][self._register[0]]
+                clock_drift_test(hours, minutes, seconds)
 
             if len(self._register) == 1 and self._register[0] in ('33001', '33002', '33003'):
                 n_value = hex(round(get_value(self)))[2:]


### PR DESCRIPTION
The `async_update` method in the solis_modbus sensor has been refactored to utilize asyncio for entity updates. Instead of using simple loops to call the update method on each entity, asyncio.gather and asyncio.to_thread are used to make the update calls asynchronously. This change should improve the efficiency of the update method, reducing the time taken and resources used.

fixes: #27 
fixes #38 

pre-release: https://github.com/Pho3niX90/solis_modbus/releases/tag/1.4.0-beta-02