### PR TITLE
Add sensor watchdog for availability timeout


### DIFF
--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -43,7 +43,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
         self._received_values = {}
 
         # Watchdog parameters
-        self._last_update = datetime.now()
+        self._last_update = datetime.now(timezone.utc).astimezone()
         self._update_timeout = timedelta(minutes=_WATCHDOG_TIMEOUT_MIN)
 
     def decimal_count(self, number: float) -> int | None:
@@ -109,7 +109,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
             if new_value is not None:
                 self._attr_native_value = new_value
                 self._attr_available = True
-                self._last_update = datetime.now()
+                self._last_update = datetime.now(timezone.utc).astimezone()
                 self.schedule_update_ha_state()
 
     async def async_update(self):
@@ -117,7 +117,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
         now = datetime.now()
         if now - self._last_update > self._update_timeout:
             _LOGGER.warning(f"No Modbus update for sensor {self._attr_name} in over {_WATCHDOG_TIMEOUT_MIN} minutes. Setting to 0.")
-            self._attr_native_value = 0
+            #self._attr_native_value = 0
             self._attr_available = False  # Set attribute unavailable (if desired)
             self.schedule_update_ha_state()
 

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -1,6 +1,6 @@
 import logging
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from datetime import datetime, timedelta
 
 from typing import List

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -43,7 +43,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
         self._received_values = {}
 
         # Watchdog parameters
-        self._last_update = datetime.now(timezone.utc).astimezone()
+        self._last_update = .now(timezone.utc).astimezone()
         self._update_timeout = timedelta(minutes=_WATCHDOG_TIMEOUT_MIN)
 
     def decimal_count(self, number: float) -> int | None:
@@ -83,7 +83,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
                 if cache_get(self.hass, 3043) == 2:
                     self._attr_native_value = 0
                     self.schedule_update_ha_state()
-                    self._last_update = datetime.now(timezone.utc).astimezone()
+                    self._last_update = .now(timezone.utc).astimezone()
                     return
 
             updated_value = int(event.data.get(VALUE))
@@ -114,7 +114,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
 
     async def async_update(self):
         """Fallback-Check: If no update for more than _WATCHDOG_TIMEOUT_MIN minutes, set values to 0 or unavailable"""
-        now = datetime.now()
+        now = datetime.now(timezone.utc).astimezone()
         if now - self._last_update > self._update_timeout:
             _LOGGER.warning(f"No Modbus update for sensor {self._attr_name} in over {_WATCHDOG_TIMEOUT_MIN} minutes. Setting to 0.")
             #self._attr_native_value = 0

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -83,7 +83,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
                 if cache_get(self.hass, 3043) == 2:
                     self._attr_native_value = 0
                     self.schedule_update_ha_state()
-                    self._last_update = datetime.now()
+                    self._last_update = datetime.now(timezone.utc).astimezone()
                     return
 
             updated_value = int(event.data.get(VALUE))

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -70,7 +70,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
 
     @callback
     def handle_modbus_update(self, event):
-        """Callback function that updates sensor when new register data is available."""
+        """Callback function that updates sensor when  register data is available."""
         updated_register = int(event.data.get(REGISTER))
         updated_controller = str(event.data.get(CONTROLLER))
 
@@ -102,7 +102,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
                     return
 
             new_value = self.base_sensor.convert_value(values)
-			# Clear received values after update
+            # Clear received values after update
             self._received_values.clear()
 
             # Update state if valid value exists

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -43,7 +43,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
         self._received_values = {}
 
         # Watchdog parameters
-        self._last_update = .now(timezone.utc).astimezone()
+        self._last_update = datetime.now(timezone.utc).astimezone()
         self._update_timeout = timedelta(minutes=_WATCHDOG_TIMEOUT_MIN)
 
     def decimal_count(self, number: float) -> int | None:
@@ -83,7 +83,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
                 if cache_get(self.hass, 3043) == 2:
                     self._attr_native_value = 0
                     self.schedule_update_ha_state()
-                    self._last_update = .now(timezone.utc).astimezone()
+                    self._last_update = datetime.now(timezone.utc).astimezone()
                     return
 
             updated_value = int(event.data.get(VALUE))

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -1,6 +1,6 @@
 import logging
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from datetime import datetime, timedelta
 
 from typing import List

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -1,7 +1,7 @@
 import logging
 
 from homeassistant.core import HomeAssistant, callback
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from typing import List
 from homeassistant.components.sensor import RestoreSensor, SensorEntity


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #187 

## ✅ Testing Steps
1. **Tested With**: Solis S5-GR1P4.6K
2. **Test Results**: Sensors become unavailable after they have not been updated for 10 min. (i.e. when inverter shuts down or Modbus connection was lost)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add watchdog for stale sensor updates

- Set sensors unavailable after timeout

- Make timestamps timezone aware

- Refresh availability on update


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_sensor.py</strong><dd><code>Add watchdog for sensor timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_sensor.py

<li>Imported datetime, timezone, and callback<br> <li> Defined _WATCHDOG_TIMEOUT_MIN constant<br> <li> Tracked last update and availability timestamps<br> <li> Implemented async_update fallback marking unavailable


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/196/files#diff-9fd594ef705e5a1c42382d7e43cf97b0914f00cf6d9f036eca58bbd755792aae">+25/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>