### PR TITLE
Fix unique ID for Load Total Consumption Energy sensor


### DIFF
--- a/custom_components/solis_modbus/sensor_data/string_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/string_sensors.py
@@ -268,7 +268,7 @@ string_sensors = [
              "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR, "state_class": SensorStateClass.TOTAL_INCREASING},
 
             {"name": "Load Total Consumption Energy",
-             "unique": "solis_modbus_inverter_total_load_power",
+             "unique": "solis_modbus_inverter_load_total_consumption_energy",
              "register": ['36052', '36053'], "device_class": SensorDeviceClass.ENERGY, "multiplier": 0.01,
              "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR, "state_class": SensorStateClass.TOTAL_INCREASING},
 


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #187 

Minor change of UID to avoid identical names.


___

### **PR Type**
Bug fix


___

### **Description**
- Rename unique sensor ID for load consumption energy


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>string_sensors.py</strong><dd><code>Rename Load Total Consumption Energy sensor unique ID</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/string_sensors.py

<li>Renamed <code>unique</code> of Load Total Consumption Energy sensor<br>   to <br><code>solis_modbus_inverter_load_total_consumption_energy</code><br> <li> Prevent duplicate sensor ID conflict


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/197/files#diff-31de825d31f0fe277a133520e0615a4b6683bca106be79dfc95aff96538b44d1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>