### PR TITLE
Introduce poll_speed and refine sensor behavior


### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Solis and equivalent Axitec, Zonneplan inverters
 - - S6-EH3P(12-20)K-H
 - - S6-EH1P6K-L-PRO
 - - S6-EH3P10K-H-ZP (https://github.com/Pho3niX90/solis_modbus/issues/191)
+- - S6-EH3P10K-H-EU (https://github.com/Pho3niX90/solis_modbus/issues/202)
 - **S6-GR1P**
 - - S6-GR1P4K (https://github.com/Pho3niX90/solis_modbus/issues/84)
 - **S5-EH1**

--- a/custom_components/solis_modbus/manifest.json
+++ b/custom_components/solis_modbus/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/Pho3niX90/solis_modbus/issues",
   "quality_scale": "silver",
   "requirements": ["pymodbus>=3.7.4"],
-  "version": "3.3.6"
+  "version": "3.3.7"
 }

--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -1356,7 +1356,7 @@ hybrid_sensors_derived = [
     {"type": "SDS", "name": "Today Net Grid Energy",
      "unique": "solis_modbus_inverter_today_net_grid_energy", "device_class": SensorDeviceClass.ENERGY,
      "multiplier": 0.1,
-     "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR, "state_class": SensorStateClass.MEASUREMENT,
+     "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR, "state_class": SensorStateClass.TOTAL_INCREASING,
      "register": ['33175', '33171']},
 
     {"type": "SDS", "name": "Inverter model definition",

--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -573,13 +573,13 @@ hybrid_sensors = [
              "unique": "solis_modbus_inverter_max_charge_current", "register": ['43012'],
              "device_class": SensorDeviceClass.CURRENT, "multiplier": 0.1,
              "unit_of_measurement": UnitOfElectricCurrent.AMPERE, "editable": True,
-             "default": 20, "min": 5, "max": 200, "step": 1, },
+             "default": 20, "min": 0, "max": 200, "step": 0.5, },
 
             {"name": "Max Discharge Current",
              "unique": "solis_modbus_inverter_max_discharge_current", "register": ['43013'],
              "device_class": SensorDeviceClass.CURRENT, "multiplier": 0.1,
              "unit_of_measurement": UnitOfElectricCurrent.AMPERE, "editable": True,
-             "default": 20, "min": 5, "max": 200, "step": 1, },
+             "default": 20, "min": 0, "max": 200, "step": 0.5, },
 
             {"type": "reserve", "register": ['43014', '43015', '43016', '43017']},
 

--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -150,7 +150,6 @@ class SolisSensorGroup:
     sensors: List[SolisBaseSensor]
 
     def __init__(self, hass, definition, controller):
-        self.poll_speed: PollSpeed = definition.get("poll_speed", PollSpeed.NORMAL if self.start_register < 40000 else PollSpeed.SLOW)
         self._sensors = list(map(lambda entity: SolisBaseSensor(
             hass=hass,
             name= entity.get("name", "reserve"),
@@ -166,8 +165,9 @@ class SolisSensorGroup:
             default=entity.get("default", 0),
             multiplier=entity.get("multiplier", 1),
             unique_id="{}_{}_{}".format(DOMAIN, controller.host, entity.get("unique", "reserve")),
-            poll_speed=self.poll_speed
+            poll_speed=definition.get("poll_speed", PollSpeed.NORMAL)
         ), definition.get("entities", [])))
+        self.poll_speed: PollSpeed = definition.get("poll_speed", PollSpeed.NORMAL if self.start_register < 40000 else PollSpeed.SLOW)
 
         _LOGGER.debug(f"Sensor group creation. start registrar = {self.start_register}, sensor count = {self.sensors_count}, registrar count = {self.registrar_count}")
         self.validate_sequential_registrars()

--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -34,7 +34,9 @@ class SolisBaseSensor:
                  step = 0.1,
                  hidden = False,
                  enabled = True,
-                 min_value: Optional[int] = None, max_value: Optional[int] = None):
+                 min_value: Optional[int] = None,
+                 max_value: Optional[int] = None,
+                 poll_speed = PollSpeed.NORMAL):
         """
         :param name: Sensor name
         :param registrars: First register address
@@ -55,6 +57,7 @@ class SolisBaseSensor:
         self.step = self.get_step(step)
         self.enabled = enabled
         self.min_value = min_value
+        self.poll_speed = poll_speed
 
         self.tcp_adjustment()
         self.dynamic_adjustments()
@@ -147,6 +150,7 @@ class SolisSensorGroup:
     sensors: List[SolisBaseSensor]
 
     def __init__(self, hass, definition, controller):
+        self.poll_speed: PollSpeed = definition.get("poll_speed", PollSpeed.NORMAL if self.start_register < 40000 else PollSpeed.SLOW)
         self._sensors = list(map(lambda entity: SolisBaseSensor(
             hass=hass,
             name= entity.get("name", "reserve"),
@@ -161,10 +165,9 @@ class SolisSensorGroup:
             min_value=entity.get("min", 0),
             default=entity.get("default", 0),
             multiplier=entity.get("multiplier", 1),
-            unique_id="{}_{}_{}".format(DOMAIN, controller.host, entity.get("unique", "reserve"))
+            unique_id="{}_{}_{}".format(DOMAIN, controller.host, entity.get("unique", "reserve")),
+            poll_speed=self.poll_speed
         ), definition.get("entities", [])))
-
-        self.poll_speed: PollSpeed = definition.get("poll_speed", PollSpeed.NORMAL if self.start_register < 40000 else PollSpeed.SLOW)
 
         _LOGGER.debug(f"Sensor group creation. start registrar = {self.start_register}, sensor count = {self.sensors_count}, registrar count = {self.registrar_count}")
         self.validate_sequential_registrars()

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from custom_components.solis_modbus.const import DOMAIN, MANUFACTURER
 from custom_components.solis_modbus.const import REGISTER, VALUE, CONTROLLER
-from custom_components.solis_modbus.data.enums import InverterType
+from custom_components.solis_modbus.data.enums import InverterType, PollSpeed
 from custom_components.solis_modbus.helpers import cache_get
 from custom_components.solis_modbus.sensors.solis_base_sensor import SolisBaseSensor
 
@@ -40,6 +40,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
         self.is_added_to_hass = False
         self._state = None
         self._received_values = {}
+        self.poll_speed = sensor.poll_speed
 
         # Watchdog parameters
         self._last_update = datetime.now(timezone.utc).astimezone()
@@ -114,7 +115,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
     async def async_update(self):
         """Fallback-Check: If no update for more than _WATCHDOG_TIMEOUT_MIN minutes, set values to 0 or unavailable"""
         now = datetime.now(timezone.utc).astimezone()
-        if now - self._last_update > self._update_timeout:
+        if (now - self._last_update > self._update_timeout) and self.poll_speed != PollSpeed.ONCE:
             _LOGGER.warning(f"⚠️ No Modbus update for sensor {self._attr_name} in over {_WATCHDOG_TIMEOUT_MIN} minutes. Setting to 0.")
             #self._attr_native_value = 0
             self._attr_available = False  # Set attribute unavailable (if desired)


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Introduce `poll_speed` control to sensors

- Prevent watchdog resets for ONCE-poll sensors

- Adjust battery current limits and steps

- Correct Today Net Grid Energy state_class


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid_sensors.py</strong><dd><code>Refine battery current limits and state_class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/hybrid_sensors.py

<li>Lowered min charge/discharge current to 0A<br> <li> Increased step granularity to 0.5A<br> <li> Changed Today Net Grid Energy to TOTAL_INCREASING


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/203/files#diff-540e84e48ae8dd4a164fe7fa970bf88a7375c29588090e2cfe4b8bf7ff16518f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>solis_base_sensor.py</strong><dd><code>Add poll_speed parameter to base sensor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_base_sensor.py

<li>Added <code>poll_speed</code> argument and attribute<br> <li> Passed poll_speed into sensor group creation<br> <li> Adjusted constructor signature formatting


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/203/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_sensor.py</strong><dd><code>Honor poll_speed in watchdog updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_sensor.py

<li>Imported <code>PollSpeed</code> enum<br> <li> Stored <code>sensor.poll_speed</code> on entity<br> <li> Skip async_update reset when poll_speed is ONCE


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/203/files#diff-9fd594ef705e5a1c42382d7e43cf97b0914f00cf6d9f036eca58bbd755792aae">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump integration version to 3.3.7</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/manifest.json

- Updated version from "3.3.6" to "3.3.7"


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/203/files#diff-cd118a6e8c28d762686f925f1dcd17c9f7075b8c31548d08c7af2120cefb5753">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>