### PR TITLE
README.md: add S6-EH1P6K-L-PLUS

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Solis and equivalent Axitec, Zonneplan inverters
 - - S6-EH3P15K-H
 - - S6-EH3P(12-20)K-H
 - - S6-EH1P6K-L-PRO
+- - S6-EH1P6K-L-PLUS
 - - S6-EH3P10K-H-ZP (https://github.com/Pho3niX90/solis_modbus/issues/191)
 - - S6-EH3P10K-H-EU (https://github.com/Pho3niX90/solis_modbus/issues/202)
 - **S6-GR1P**


### PR DESCRIPTION
add S6-EH1P6K-L-PLUS to list of supported inverters. Not sure if there is a difference between "pro" and "plus", but in case it matters...