### PR TITLE
Enhance S6-EH3P10K-H-ZP support and power settings


### DIFF
--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -63,15 +63,7 @@ class SolisBaseSensor:
         self.category = category
         self.identification = identification
 
-        self.tcp_adjustment()
         self.dynamic_adjustments()
-
-    def tcp_adjustment(self):
-        """Adjust multiplier if using WAVESHARE and relevant registers are present."""
-        if InverterFeature.TCP in self.controller.inverter_config.features:
-            waveshare_registers = {33142, 33161, 33162, 33163, 33164, 33165, 33166, 33167, 33168}
-            if waveshare_registers.intersection(self.registrars):
-                self.multiplier = 0.01
 
     def dynamic_adjustments(self):
         #
@@ -79,9 +71,15 @@ class SolisBaseSensor:
         # RHI-1P(5-10)K-HVES-5G/RHI-3P(5-10)K-HVES-5G/RAI-3K-48ES-5G: 1<-->1W, setting range: 0~30000;
         # S6 model: 1<-->100W,
         #
-        if 43074 in self.registrars:
-            if self.controller.inverter_config.model in ("RHI-1P", "RHI-3P", "RAI-3K-48ES-5G"):
+        if self.controller.inverter_config.model in ("RHI-1P", "RHI-3P", "RAI-3K-48ES-5G"):
+            if 43074 in self.registrars:
                 self.multiplier = 1
+
+        # adjust some registers for S6-EH3P10K-H-ZP inverter type
+        elif self.controller.inverter_config.model in ("S6-EH3P10K-H-ZP"):
+            registers = {33142, 33161, 33162, 33163, 33164, 33165, 33166, 33167, 33168}
+            if registers.intersection(self.registrars):
+                self.multiplier = 0.01
 
 
     def adjust_max(self, max_default):


### PR DESCRIPTION
### **User description**
The diff in multipliers are related to the invertertype (or the firmware version) and not related to the TCP version of ModBus. TCP and RTU Modbus protocols only differ in the transport/session layers, and not in the application layers. 

In basis both follow the RS485_MODBUS RTU Hybrid Inverter Protocol Ver3.2 with some diffs for the S6-EH3P10K-H-ZP version in the S6-EH3P range

## 🔄 Related Issues
#191
https://github.com/Pho3niX90/solis_modbus/pull/199

## ✅ Testing Steps
1. Tested with S6-EH3P10K-H-ZP


___

### **PR Type**
Enhancement


___

### **Description**
- Increase RC power setting ranges to 10000.

- Add S6-EH3P10K-H-ZP inverter multiplier override.

- Remove WAVESHARE TCP adjustment logic.

- Disable manual number sensor min/max steps.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid_sensors.py</strong><dd><code>Extend RC power setting ranges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/hybrid_sensors.py

<li>Increased max limits from 6000 to 10000 for RC settings.<br> <li> Added "step": 10 parameter to power control sensors.


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/213/files#diff-540e84e48ae8dd4a164fe7fa970bf88a7375c29588090e2cfe4b8bf7ff16518f">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_base_sensor.py</strong><dd><code>Refactor base sensor adjustments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_base_sensor.py

<li>Removed WAVESHARE TCP adjustment method.<br> <li> Added dynamic multiplier logic for S6-EH3P10K-H-ZP model.<br> <li> Changed default max_value to follow entity config.<br> <li> Adjusted min_max boundaries based on inverter config.


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/213/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+12/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_number_sensor.py</strong><dd><code>Disable manual min/max/step overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_number_sensor.py

- Commented out manual min/max/step override code.


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/213/files#diff-12de5d2a79db4982e540517bacb61591ae1560a31897d2b123b51a5be1cd2b24">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>