### PR TITLE
Add slave ID support and power limit enhancements


### DIFF
--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -13,6 +13,7 @@ from .const import DOMAIN, CONTROLLER, TIME_ENTITIES
 from .data.enums import InverterFeature
 from .data.solis_config import SOLIS_INVERTERS, InverterConfig, InverterType
 from .data_retrieval import DataRetrieval
+from .helpers import get_controller, set_controller
 from .modbus_controller import ModbusController
 from .sensors.solis_base_sensor import SolisSensorGroup, SolisBaseSensor
 from .sensors.solis_derived_sensor import SolisDerivedSensor
@@ -43,9 +44,10 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry):
         address = call.data.get('address')
         value = call.data.get('value')
         host = call.data.get("host")
+        slave = call.data.get("slave", 1)
 
         if host:
-            controller = hass.data[DOMAIN][CONTROLLER][host]
+            controller = get_controller(hass, host, slave)
             hass.create_task(controller.async_write_holding_register(int(address), int(value)))
         else:
             for controller in hass.data[DOMAIN][CONTROLLER].values():
@@ -201,7 +203,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     ]
 
     # Store controller in HA data
-    hass.data[DOMAIN][CONTROLLER][host] = controller
+    set_controller(hass, controller)
 
     _LOGGER.debug(f"Config entry setup for host {host}, port {port}")
 

--- a/custom_components/solis_modbus/config_flow.py
+++ b/custom_components/solis_modbus/config_flow.py
@@ -69,7 +69,7 @@ class ModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if await self._validate_config(user_input):
-                await self.async_set_unique_id(user_input["host"])
+                await self.async_set_unique_id("{}_{}".format(user_input["host"], user_input["slave"]))
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(title=f"Solis: {user_input['host']}", data=user_input)
 

--- a/custom_components/solis_modbus/helpers.py
+++ b/custom_components/solis_modbus/helpers.py
@@ -103,7 +103,13 @@ def cache_save(hass: HomeAssistant, register: str | int, value):
 def cache_get(hass: HomeAssistant, register: str | int):
     return hass.data[DOMAIN][VALUES].get(str(register), None)
 
-def get_controller(hass: HomeAssistant, controller_host: str):
+def set_controller(hass: HomeAssistant, controller):
+    hass.data[DOMAIN][CONTROLLER]["{}_{}".format(controller.host, controller.slave)] = controller
+
+def get_controller(hass: HomeAssistant, controller_host: str, controller_slave: int):
+    controller = hass.data[DOMAIN][CONTROLLER]["{}_{}".format(controller_host, controller_slave)]
+    if controller:
+        return controller
     return hass.data[DOMAIN][CONTROLLER][controller_host]
 
 def split_s32(s32_values: List[int]):

--- a/custom_components/solis_modbus/number.py
+++ b/custom_components/solis_modbus/number.py
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_devices):
     """Set up the number platform."""
-    controller: ModbusController = get_controller(hass, config_entry.data.get("host"))
+    controller: ModbusController = get_controller(hass, config_entry.data.get("host"), config_entry.data.get("slave", 1))
     # We only want this platform to be set up via discovery.
     _LOGGER.info("Options %s", len(config_entry.options))
 

--- a/custom_components/solis_modbus/select.py
+++ b/custom_components/solis_modbus/select.py
@@ -16,7 +16,7 @@ async def async_setup_entry(
         config_entry: ConfigEntry,
         async_add_devices,
 ) -> None:
-    controller: ModbusController = get_controller(hass, config_entry.data.get("host"))
+    controller: ModbusController = get_controller(hass, config_entry.data.get("host"), config_entry.data.get("slave", 1))
     # We only want this platform to be set up via discovery.
     _LOGGER.info("Options %s", len(config_entry.options))
 

--- a/custom_components/solis_modbus/sensor.py
+++ b/custom_components/solis_modbus/sensor.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
     """Set up Modbus sensors from a config entry."""
-    controller: ModbusController = get_controller(hass, config_entry.data.get("host"))
+    controller: ModbusController = get_controller(hass, config_entry.data.get("host"), config_entry.data.get("slave", 1))
     sensor_entities: List[SolisSensor] = []
     sensor_derived_entities: List[SensorEntity] = []
     hass.data[DOMAIN][VALUES] = {}

--- a/custom_components/solis_modbus/sensor_data/string_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/string_sensors.py
@@ -167,12 +167,12 @@ string_sensors = [
         ]
     },
     {
-        "register_start": 3069,
+        "register_start": 3089,
         "poll_speed": PollSpeed.SLOW,
         "entities": [
-            {"name": "Power Limitation Switch", "unique": "solis_modbus_power_limitation_switch",
+            {"name": "Power Limitation Switch (89)", "unique": "solis_modbus_power_limitation_switch",
              "state_class": SensorStateClass.MEASUREMENT, "hidden": True,
-             "register": ['3069'], "multiplier": 1},
+             "register": ['3089'], "multiplier": 1},
         ]
     },
     {

--- a/custom_components/solis_modbus/switch.py
+++ b/custom_components/solis_modbus/switch.py
@@ -126,7 +126,8 @@ async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_devices):
         ])
     elif modbus_controller.inverter_config.type == InverterType.GRID or modbus_controller.inverter_config.type == InverterType.STRING:
         switch_sensors.extend([{
-            "register": 3069,
+            "read_register": 3089,
+            "write_register": 3069,
             "entities": [
                 {"on_value": 0xAA, "off_value": 0x55, "name": "Enable power limit feature"},
             ]

--- a/custom_components/solis_modbus/switch.py
+++ b/custom_components/solis_modbus/switch.py
@@ -3,17 +3,16 @@ from typing import List
 
 from homeassistant.config_entries import ConfigEntry
 
-from custom_components.solis_modbus import ModbusController
-from custom_components.solis_modbus.const import DOMAIN, CONTROLLER,  ENTITIES, SWITCH_ENTITIES
+from custom_components.solis_modbus import ModbusController, get_controller
+from custom_components.solis_modbus.const import DOMAIN, ENTITIES, SWITCH_ENTITIES
 from custom_components.solis_modbus.data.enums import InverterType
-from custom_components.solis_modbus.data.solis_config import InverterConfig
 from custom_components.solis_modbus.sensors.solis_binary_sensor import SolisBinaryEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_devices):
-    modbus_controller: ModbusController = hass.data[DOMAIN][CONTROLLER][config_entry.data.get("host")]
+    modbus_controller: ModbusController = get_controller(hass, config_entry.data.get("host"), config_entry.data.get("slave", 1))
 
     switch_sensors = [
         {

--- a/custom_components/solis_modbus/time.py
+++ b/custom_components/solis_modbus/time.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_devices):
     """Set up the time platform."""
-    modbus_controller: ModbusController = get_controller(hass, config_entry.data.get("host"))
+    modbus_controller: ModbusController = get_controller(hass, config_entry.data.get("host"), config_entry.data.get("slave", 1))
 
     inverter_config = modbus_controller.inverter_config
 

--- a/tests/test_select_definitions_from_code.py
+++ b/tests/test_select_definitions_from_code.py
@@ -9,6 +9,7 @@ from custom_components.solis_modbus.select import async_setup_entry
 async def test_select_bit_position_requires_combinations_are_unique():
     controller = MagicMock()
     controller.host = "10.0.0.1"
+    controller.slave = 1
     controller.connected.return_value = True
     controller.inverter_config = MagicMock()
     controller.inverter_config.type = InverterType.HYBRID
@@ -23,7 +24,7 @@ async def test_select_bit_position_requires_combinations_are_unique():
     hass.data = {
         DOMAIN: {
             CONTROLLER: {
-                "10.0.0.1": controller
+                "10.0.0.1_1": controller
             }
         }
     }

--- a/tests/test_switch_definitions_from_code.py
+++ b/tests/test_switch_definitions_from_code.py
@@ -9,6 +9,7 @@ from custom_components.solis_modbus.switch import async_setup_entry
 async def test_switch_bit_position_requires_combinations_are_unique():
     controller = MagicMock()
     controller.host = "10.0.0.1"
+    controller.slave = 1
     controller.connected.return_value = True
     controller.inverter_config = MagicMock()
     controller.inverter_config.type = InverterType.HYBRID
@@ -22,7 +23,7 @@ async def test_switch_bit_position_requires_combinations_are_unique():
     hass.data = {
         DOMAIN: {
             CONTROLLER: {
-                "10.0.0.1": controller
+                "10.0.0.1_1": controller
             }
         }
     }


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #180 #173


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
• Support multiple inverters by slave ID
• Persist controllers keyed by host and slave
• Separate read/write register handling for switches
• Update power limit registers and sensors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Use get/set controller with host and slave</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-90c384b3c13c51777899c6bb6f69f01762e31d9fed1da9933a765b6e6fe60be3">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.py</strong><dd><code>Implement set_controller and slave-aware get_controller</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-62575804e6e6479bc99910af8f216c62e76af4bc818fc0a93b80c8726b6b65be">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>number.py</strong><dd><code>Retrieve controller by host and slave</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-05c207eb281aae5baf9b42453f10fb6089b351aae3b2ff4bbab3b3b242d791ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>select.py</strong><dd><code>Pass slave parameter to get_controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-8c8310389c50153eeaa1b9423eccd45605d25b1a8ee0c0c3adad6608c1089b0c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sensor.py</strong><dd><code>Add slave ID when fetching controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-0039343b174fc89b56610cf2a90a1e0aac311242088211ca1c03f30221752e68">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>string_sensors.py</strong><dd><code>Shift power limit registers to 3089</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-31de825d31f0fe277a133520e0615a4b6683bca106be79dfc95aff96538b44d1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>switch.py</strong><dd><code>Configure separate read/write registers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-90ae7cd6d8b06fc32ed801488e14644b801c46396f27f1421bdc3b96fc3d2cbe">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>time.py</strong><dd><code>Fetch controller with slave ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-985db4ef648e7be8a644c569c39b8c052135ec8eea28030589fe3693558a2022">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config_flow.py</strong><dd><code>Include slave in unique config entry ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-2e983e3a2a647135a82c37e4ee143bab14008b7fa1c13da9da8dea903c2e14c3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>solis_binary_sensor.py</strong><dd><code>Add write_register and fix debug logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/226/files#diff-d39102b709446949c1462374be814672bb33e644165cf47272371f7e7da354e1">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>