### PR TITLE
Add Operating Mode (register 33122)

### DIFF
--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -239,6 +239,15 @@ hybrid_sensors = [
         ]
     },
     {
+        "register_start": 33122,
+        "poll_speed": PollSpeed.FAST,
+        "entities": [
+            {"name": "Operating Mode", "category": Category.BASIC_INFORMATION,
+             "unique": "solis_modbus_inverter_operating_mode", "register": ['33122'],
+             "multiplier": 0, "state_class": SensorStateClass.MEASUREMENT},
+        ]
+    },
+    {
         "register_start": 33132,
         "poll_speed": PollSpeed.FAST,
         "entities": [


### PR DESCRIPTION
The actual operating mode of the inverter is given by register 33122 and Appendix 8
This maybe converted into an enum at a later stage. Now mainly used to debug the switch settings (registers 33132 and 43110)

![image](https://github.com/user-attachments/assets/5a778f40-2a15-4df4-a3f3-9b40db304c67)

ps I actually have seen bit 9 and 10 being set (values 512 & 1024) but these are not given in the specs I have