### PR TITLE
Fix model condition for S6-EH3P10K-H-ZP multiplier logic


### DIFF
--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -76,7 +76,7 @@ class SolisBaseSensor:
                 self.multiplier = 1
 
         # adjust some registers for S6-EH3P10K-H-ZP inverter type
-        elif self.controller.inverter_config.model in ("S6-EH3P10K-H-ZP"):
+        elif self.controller.inverter_config.model == "S6-EH3P10K-H-ZP":
             registers = {33142, 33161, 33162, 33163, 33164, 33165, 33166, 33167, 33168}
             if registers.intersection(self.registrars):
                 self.multiplier = 0.01


### PR DESCRIPTION
## 🔄 Related Issues
Closes #224

## ✅ Testing Steps
Code review

## ➕ Additional Notes
The Tuple with one element ("S6-EH3P10K-H-ZP") is not a tuple—it's just a string. As such the substring S6-EH3P is also resolving into True and the multipler adjustment is executed

