### PR TITLE
Prevent division by zero in power calculation


### DIFF
--- a/custom_components/solis_modbus/sensors/solis_derived_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_derived_sensor.py
@@ -111,7 +111,7 @@ class SolisDerivedSensor(RestoreSensor, SensorEntity):
                 active_power = self.base_sensor.convert_value([self._received_values[self._register[0]], self._received_values[self._register[1]]])
                 reactive_power = self.base_sensor.convert_value([self._received_values[self._register[2]], self._received_values[self._register[3]]])
 
-                if active_power is 0 or reactive_power is 0:
+                if active_power == 0 or reactive_power == 0:
                     new_value = 1
                 else:
                     new_value = round(active_power / ((active_power**2 + reactive_power**2) ** 0.5),3)

--- a/custom_components/solis_modbus/sensors/solis_derived_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_derived_sensor.py
@@ -110,7 +110,11 @@ class SolisDerivedSensor(RestoreSensor, SensorEntity):
             if 33079  in self._register or 33080 in self._register or 33081 in self._register or 33082 in self._register:
                 active_power = self.base_sensor.convert_value([self._received_values[self._register[0]], self._received_values[self._register[1]]])
                 reactive_power = self.base_sensor.convert_value([self._received_values[self._register[2]], self._received_values[self._register[3]]])
-                new_value = round(active_power / ((active_power**2 + reactive_power**2) ** 0.5),3)
+
+                if active_power is 0 or reactive_power is 0:
+                    new_value = 1
+                else:
+                    new_value = round(active_power / ((active_power**2 + reactive_power**2) ** 0.5),3)
 
             if 33135 in self._register and len(self._register) == 4:
                 registers = self._register.copy()


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #236


___

### **PR Type**
Bug fix


___

### **Description**
- Add guard to prevent division by zero

- Default `new_value` to 1 when power zero

- Retain original ratio calculation otherwise


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_derived_sensor.py</strong><dd><code>Guard against zero-power division</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_derived_sensor.py

<li>Check for zero <code>active_power</code> or <code>reactive_power</code><br> <li> Return 1 as <code>new_value</code> when zeros detected<br> <li> Use original ratio formula for non-zero case


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/237/files#diff-dcaabc83e45e8f85ccb48d3e876870a70460908d41623ab7fa6161dcb953521b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>