### PR TITLE
Increase max charge/discharge current step resolution


### DIFF
--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -602,13 +602,13 @@ hybrid_sensors = [
              "unique": "solis_modbus_inverter_max_charge_current", "register": ['43012'],
              "device_class": SensorDeviceClass.CURRENT, "multiplier": 0.1,
              "unit_of_measurement": UnitOfElectricCurrent.AMPERE, "editable": True,
-             "default": 20, "min": 0, "max": 200, "step": 0.5, },
+             "default": 20, "min": 0, "max": 200, "step": 0.1, },
 
             {"name": "Max Discharge Current", "category": Category.BATTERY_SETTING,
              "unique": "solis_modbus_inverter_max_discharge_current", "register": ['43013'],
              "device_class": SensorDeviceClass.CURRENT, "multiplier": 0.1,
              "unit_of_measurement": UnitOfElectricCurrent.AMPERE, "editable": True,
-             "default": 20, "min": 0, "max": 200, "step": 0.5, },
+             "default": 20, "min": 0, "max": 200, "step": 0.1, },
 
             {"type": "reserve", "register": ['43014', '43015']},
 


### PR DESCRIPTION
### **User description**
for highvoltage battery more useable


___

### **PR Type**
Enhancement


___

### **Description**
- Increase current step resolution to 0.1A

- Update Max Charge Current granularity

- Update Max Discharge Current granularity


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid_sensors.py</strong><dd><code>Enhance current setting resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/hybrid_sensors.py

<li>Changed <code>step</code> from 0.5 to 0.1 for Max Charge Current<br> <li> Changed <code>step</code> from 0.5 to 0.1 for Max Discharge Current


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/247/files#diff-540e84e48ae8dd4a164fe7fa970bf88a7375c29588090e2cfe4b8bf7ff16518f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>