### PR TITLE
Add grid feed in power limit switch

### DIFF
--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -664,9 +664,14 @@ hybrid_sensors = [
         ]
     },
     {
-        "register_start": 43074,
+        "register_start": 43073,
         "poll_speed": PollSpeed.SLOW,
         "entities": [
+            {"name": "Grid feed in Switch value", "category": Category.AC_PORT_SETTING,
+             "unique": "solis_modbus_inverter_grid_feed_in_switch_value", "register": ['43073'],
+             "multiplier": 1,
+             "hidden": True,
+             "state_class": SensorStateClass.MEASUREMENT},
             {"name": "Backflow Power", "category": Category.AC_PORT_SETTING,
              "unique": "solis_modbus_inverter_backflow_power", "register": ['43074'],
              "device_class": SensorDeviceClass.POWER, "multiplier": 100,

--- a/custom_components/solis_modbus/switch.py
+++ b/custom_components/solis_modbus/switch.py
@@ -29,6 +29,11 @@ async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_devices):
             "entities": [
                 {"name": "Power State", "on_value": 190, "off_value": 222},
             ]
+            },{
+                "register": 43073,
+                "entities": [
+                    {"bit_position": 4, "name": "Grid feed in power limit switch"},
+                ]
             },
             {
                 "register": 43110,


### PR DESCRIPTION
## 🔄 Related Issues
Closes #251 

## ✅ Testing Steps
1. **Tested With**: Solis S6-EH3P10K-H-EU
2. **Test Results**: Switch updates correctly, no errors

## ➕ Additional Notes
There are more bits described for the register in Appendix 12 in the "RS485_MODBUS RTU Hybrid Inverter Protocol Ver3.1" however, my knowledge about those functions is limited so I only added the Grid feed in power limit switch (the function I want to use) and have verified that it works on my inverter.

