### PR TITLE
Fix timezone-aware drift calculation in inverter helper


### DIFF
--- a/custom_components/solis_modbus/helpers.py
+++ b/custom_components/solis_modbus/helpers.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List
 
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_utils
 from custom_components.solis_modbus import DOMAIN
 from custom_components.solis_modbus.const import DRIFT_COUNTER, VALUES, CONTROLLER
 
@@ -29,8 +30,11 @@ def extract_serial_number(values):
 
 
 def clock_drift_test(hass, controller, hours, minutes, seconds):
-    current_time = datetime.now()
-    device_time = datetime(current_time.year, current_time.month, current_time.day, hours, minutes, seconds)
+    current_time = dt_utils.now()
+    device_time = datetime(
+        current_time.year, current_time.month, current_time.day, hours, minutes, seconds,
+        tzinfo=current_time.tzinfo
+    )
     total_drift = (current_time - device_time).total_seconds()
 
     # Ensure structure


### PR DESCRIPTION
### **User description**
## ✅ Testing Steps
1. **Tested With**:  Solis S6-EH3P10K-H-EU
2. **Test Results**: Correct time in inverter

## ➕ Additional Notes
My inverter has been showing UTC for a while instead of the configured time zone.
I guess it is because of my server running on UTC time and datetime.now() is therefore returning the time in UTC. 
This change is just to compare the timestamp from the inverter with the HA configured timezone instead of UTC.

I hate time zones...


___

### **PR Type**
Bug fix


___

### **Description**
- Use HA's timezone-aware now() for current time

- Attach tzinfo to device_time in drift calculation

- Import dt_utils from homeassistant.util.dt


___

### **Changes diagram**

```mermaid
flowchart LR
  A["HA util dt.now() (tz-aware)"] -- "get current_time" --> B["device_time with tzinfo"]
  B -- "calculate time difference" --> C["total_drift (seconds)"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.py</strong><dd><code>Add timezone-aware now() and tzinfo propagation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/helpers.py

<li>Imported <code>dt_utils</code> for timezone support<br> <li> Replaced <code>datetime.now()</code> with <code>dt_utils.now()</code><br> <li> Propagated <code>current_time.tzinfo</code> to <code>device_time</code><br> <li> Preserved drift calculation logic unchanged


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/254/files#diff-62575804e6e6479bc99910af8f216c62e76af4bc818fc0a93b80c8726b6b65be">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>