### PR TITLE
Dynamic watchdog timeout based on poll interval


### DIFF
--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -44,7 +44,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
 
         # Watchdog parameters
         self._last_update = datetime.now(timezone.utc).astimezone()
-        self._update_timeout = timedelta(minutes=_WATCHDOG_TIMEOUT_MIN)
+        self._update_timeout = timedelta(minutes=self.base_sensor.controller.poll_speed.get(sensor.poll_speed, 0) + _WATCHDOG_TIMEOUT_MIN)
 
     def decimal_count(self, number: float) -> int | None:
         """Returns the number of decimal places in a given number."""


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #248


___

### **PR Type**
Enhancement


___

### **Description**
- Calculate watchdog timeout using poll interval

- Add minimum timeout offset


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_sensor.py</strong><dd><code>Dynamic watchdog timeout calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_sensor.py

<li>Updated <code>_update_timeout</code> initialization<br> <li> Derived timeout via <code>controller.poll_speed.get(sensor.poll_speed, 0)</code><br> <li> Added <code>_WATCHDOG_TIMEOUT_MIN</code> minutes offset


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/260/files#diff-9fd594ef705e5a1c42382d7e43cf97b0914f00cf6d9f036eca58bbd755792aae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>