### PR TITLE
Accommodate pymodbus API changes: use device_id

### DIFF
--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -175,7 +175,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass=hass,
         host=host,
         port=port,
-        slave=slave,
+        device_id=slave,
         identification=identification,
         fast_poll=poll_interval_fast,
         normal_poll=poll_interval_normal,

--- a/custom_components/solis_modbus/manifest.json
+++ b/custom_components/solis_modbus/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Pho3niX90/solis_modbus/issues",
   "quality_scale": "silver",
-  "requirements": ["pymodbus>=3.7.4"],
+  "requirements": ["pymodbus>=3.11.1"],
   "version": "3.3.12"
 }

--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class ModbusController:
     def __init__(self, hass, host, inverter_config: InverterConfig, sensor_groups: List[SolisSensorGroup] = None,
-                 derived_sensors: List[SolisDerivedSensor] = None, slave=1, port=502, fast_poll=5, normal_poll=15, slow_poll=30, identification: str | None = None):
+                 derived_sensors: List[SolisDerivedSensor] = None, device_id=1, port=502, fast_poll=5, normal_poll=15, slow_poll=30, identification: str | None = None):
         self.hass = hass
         self.host = host
         self.port = port
@@ -93,7 +93,7 @@ class ModbusController:
                 await self.inter_frame_wait(is_write=True)  # Delay before write
                 int_value = int(value)
                 int_register = register if is_number(register) else int(register)
-                result = await self.client.write_register(address=int_register, value=int_value, slave=self.slave)
+                result = await self.client.write_register(address=int_register, value=int_value, device_id=self.slave)
                 _LOGGER.debug(
                     f"({self.host}.{self.slave}) Write Holding Register register = {int_register}, value = {value}, int_value = {int_value}: {result}")
 
@@ -127,7 +127,7 @@ class ModbusController:
             await self.connect()
             async with self.poll_lock:
                 await self.inter_frame_wait(is_write=True)
-                result = await self.client.write_registers(address=start_register, values=values, slave=self.slave)
+                result = await self.client.write_registers(address=start_register, values=values, device_id=self.slave)
                 _LOGGER.debug(f"({self.host}.{self.slave}) Write Holding Registers register = {start_register}, values = {values}: {result}")
 
                 if result.isError():
@@ -191,7 +191,7 @@ class ModbusController:
         """
         try:
             await self.connect()
-            result = await self.client.read_input_registers(address=register, count=count, slave=self.slave)
+            result = await self.client.read_input_registers(address=register, count=count, device_id=self.slave)
             _LOGGER.debug(f"({self.host}.{self.slave}) Register {register}: {result.registers}")
             await self.inter_frame_wait()
             self._last_modbus_success = datetime.now(UTC)
@@ -215,7 +215,7 @@ class ModbusController:
         """
         try:
             await self.connect()
-            result = await self.client.read_holding_registers(address=register, count=count, slave=self.slave)
+            result = await self.client.read_holding_registers(address=register, count=count, device_id=self.slave)
             _LOGGER.debug(f"({self.host}.{self.slave}) Holding Register {register}: {result.registers}")
             await self.inter_frame_wait()
             self._last_modbus_success = datetime.now(UTC)

--- a/tests/test_modbus_controller.py
+++ b/tests/test_modbus_controller.py
@@ -30,7 +30,7 @@ class TestModbusController(unittest.TestCase):
             hass=self.hass,
             host="192.168.1.100",
             inverter_config=self.inverter_config,
-            slave=1,
+            device_id=1,
             port=502,
             fast_poll=5,
             normal_poll=15,
@@ -83,7 +83,7 @@ class TestModbusController(unittest.TestCase):
         result = await self.controller.async_read_input_register(100)
         
         self.assertEqual([42], result)
-        self.mock_client.read_input_registers.assert_called_once_with(address=100, count=1, slave=1)
+        self.mock_client.read_input_registers.assert_called_once_with(address=100, count=1, device_id=1)
     
     async def test_async_read_input_register_failure(self):
         """Test failed read of input register."""
@@ -93,7 +93,7 @@ class TestModbusController(unittest.TestCase):
         result = await self.controller.async_read_input_register(100)
         
         self.assertIsNone(result)
-        self.mock_client.read_input_registers.assert_called_once_with(address=100, count=1, slave=1)
+        self.mock_client.read_input_registers.assert_called_once_with(address=100, count=1, device_id=1)
     
     async def test_async_read_holding_register_success(self):
         """Test successful read of holding register."""
@@ -105,7 +105,7 @@ class TestModbusController(unittest.TestCase):
         result = await self.controller.async_read_holding_register(100)
         
         self.assertEqual([42], result)
-        self.mock_client.read_holding_registers.assert_called_once_with(address=100, count=1, slave=1)
+        self.mock_client.read_holding_registers.assert_called_once_with(address=100, count=1, device_id=1)
     
     async def test_async_read_holding_register_failure(self):
         """Test failed read of holding register."""
@@ -115,7 +115,7 @@ class TestModbusController(unittest.TestCase):
         result = await self.controller.async_read_holding_register(100)
         
         self.assertIsNone(result)
-        self.mock_client.read_holding_registers.assert_called_once_with(address=100, count=1, slave=1)
+        self.mock_client.read_holding_registers.assert_called_once_with(address=100, count=1, device_id=1)
     
     async def test_async_write_holding_register(self):
         """Test queuing a write to a holding register."""


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #[issue number] (if applicable)

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Rename `slave` parameter to `device_id`

- Update client calls to use `device_id`

- Adjust tests to assert `device_id` usage

- Bump `pymodbus` requirement to ≥3.11.1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["async_setup_entry: `slave` → `device_id`"]
  B["ModbusController ctor uses `device_id`"]
  C["Client calls with `device_id`"]
  D["Tests updated for `device_id`"]
  A --> B --> C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Rename slave to device_id in setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/__init__.py

<ul><li>Changed ModbusController instantiation argument<br> <li> Replaced <code>slave</code> with <code>device_id</code> in setup entry</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/276/files#diff-90c384b3c13c51777899c6bb6f69f01762e31d9fed1da9933a765b6e6fe60be3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>modbus_controller.py</strong><dd><code>Use device_id in ModbusController methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/modbus_controller.py

<ul><li>Renamed constructor parameter <code>slave</code> to <code>device_id</code><br> <li> Updated all <code>write_register*</code> calls to use <code>device_id</code><br> <li> Updated <code>read_input_registers</code> and <code>read_holding_registers</code> calls</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/276/files#diff-e230937b651240e2eb7a7c8fd2f5c2db9521105ae3be0352f3439850b9089f1e">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Update pymodbus version requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/manifest.json

- Bumped `pymodbus` requirement to ≥3.11.1


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/276/files#diff-cd118a6e8c28d762686f925f1dcd17c9f7075b8c31548d08c7af2120cefb5753">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_modbus_controller.py</strong><dd><code>Update tests for device_id parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_modbus_controller.py

<ul><li>Updated test setup to pass <code>device_id</code> instead of <code>slave</code><br> <li> Adjusted assertions to expect <code>device_id</code> param<br> <li> Added missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/276/files#diff-0109f71532f05ee50b83547d0dccf3b6e957dad273c03f19fda70750c052a356">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

