### PR TITLE
Use device_id instead of slave for controllers

### DIFF
--- a/custom_components/solis_modbus/helpers.py
+++ b/custom_components/solis_modbus/helpers.py
@@ -108,7 +108,7 @@ def cache_get(hass: HomeAssistant, register: str | int):
     return hass.data[DOMAIN][VALUES].get(str(register), None)
 
 def set_controller(hass: HomeAssistant, controller):
-    hass.data[DOMAIN][CONTROLLER]["{}_{}".format(controller.host, controller.slave)] = controller
+    hass.data[DOMAIN][CONTROLLER]["{}_{}".format(controller.host, controller.device_id)] = controller
 
 def get_controller(hass: HomeAssistant, controller_host: str, controller_slave: int):
     controller = hass.data[DOMAIN][CONTROLLER]["{}_{}".format(controller_host, controller_slave)]
@@ -127,4 +127,4 @@ def _any_in(target: List[int], collection: set[int]) -> bool:
     return any(item in collection for item in target)
 
 def is_correct_controller(controller, host: str, slave: int):
-    return controller.host == host and controller.slave == slave
+    return controller.host == host and controller.device_id == slave


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #275

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix


___

### **Description**
- Use `device_id` in controller mapping key

- Update controller identity check to `device_id`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.py</strong><dd><code>Replace slave with device_id in controller functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/helpers.py

<ul><li>Changed mapping key to use <code>device_id</code> instead of <code>slave</code> in <br><code>set_controller</code><br> <li> Updated <code>is_correct_controller</code> comparison to use <code>device_id</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/279/files#diff-62575804e6e6479bc99910af8f216c62e76af4bc818fc0a93b80c8726b6b65be">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

