### PR TITLE
Expose Modbus slave attribute mirroring device ID

### DIFF
--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -24,6 +24,8 @@ class ModbusController:
         self.host = host
         self.port = port
         self.device_id = device_id
+        # todo: quick fix, replace naming where applicable later.
+        self.slave = device_id
         self.identification = identification
         self.client: AsyncModbusTcpClient = AsyncModbusTcpClient(host=self.host, port=self.port, timeout=5, retries=5)
         self.connect_failures = 0


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #275

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `slave` attribute mirroring `device_id`

- Insert TODO for future naming refactor


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modbus_controller.py</strong><dd><code>Introduce slave attribute for device ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/modbus_controller.py

<ul><li>Added <code>self.slave</code> property set to <code>device_id</code><br> <li> Included TODO comment for naming refactor</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/280/files#diff-e230937b651240e2eb7a7c8fd2f5c2db9521105ae3be0352f3439850b9089f1e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

