### PR TITLE
Refactor ModbusController: replace slave with device_id and expose properties

### DIFF
--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -10,8 +10,7 @@ from pymodbus.client import AsyncModbusTcpClient, AsyncModbusSerialClient
 from custom_components.solis_modbus.client_manager import ModbusClientManager
 from custom_components.solis_modbus.const import (
     DOMAIN, REGISTER, VALUE, CONTROLLER, SLAVE,
-    CONN_TYPE_TCP, CONN_TYPE_SERIAL, CONF_SERIAL_PORT,
-    CONF_BAUDRATE, CONF_BYTESIZE, CONF_PARITY, CONF_STOPBITS,
+    CONN_TYPE_TCP, CONN_TYPE_SERIAL,
     DEFAULT_BAUDRATE, DEFAULT_BYTESIZE, DEFAULT_PARITY, DEFAULT_STOPBITS
 )
 from custom_components.solis_modbus.data.enums import PollSpeed
@@ -270,7 +269,7 @@ class ModbusController:
             await self.connect()
             async with self.poll_lock:
                 await self.inter_frame_wait()
-                result = await self.client.read_input_registers(address=register, count=count, slave=self.device_id)
+                result = await self.client.read_input_registers(address=register, count=count, device_id=self.device_id)
                 _LOGGER.debug(
                     f"({self.host}.{self.device_id}) Read Input Registers: register = {register}, count = {count}")
 
@@ -302,7 +301,7 @@ class ModbusController:
             await self.connect()
             async with self.poll_lock:
                 await self.inter_frame_wait()
-                result = await self.client.read_holding_registers(address=register, count=count, slave=self.device_id)
+                result = await self.client.read_holding_registers(address=register, count=count, device_id=self.device_id)
                 _LOGGER.debug(
                     f"({self.host}.{self.device_id}) Read Holding Registers: register = {register}, count = {count}")
 
@@ -419,6 +418,29 @@ class ModbusController:
         return self._derived_sensors
 
     @property
+    def sensor_derived_groups(self):
+        """Gets the derived sensor groups associated with this controller."""
+        return self._derived_sensors
+
+    @property
+    def last_modbus_request(self):
+        """Gets the timestamp of the last Modbus request.
+
+        Returns:
+            float: The timestamp of the last Modbus request (from time.monotonic()).
+        """
+        return self._last_modbus_request
+
+    @property
     def last_modbus_success(self):
         """Returns the timestamp of the last successful Modbus operation."""
         return self._last_modbus_success
+
+    @property
+    def device_identification(self):
+        """Gets the device identification string.
+
+        Returns:
+            str: The device identification string, or an empty string if not available.
+        """
+        return f" {self.identification}" if self.identification else ""


### PR DESCRIPTION
### **User description**
…lated tests, and add new controller properties with corresponding unit tests.

## 🔄 Related Issues
Closes #[issue number] (if applicable)

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces pymodbus `slave` arg with `device_id` in read operations and adds new controller properties with corresponding unit tests.
> 
> - **Controller (`custom_components/solis_modbus/modbus_controller.py`)**:
>   - Replace `slave` with `device_id` in `read_input_registers` and `read_holding_registers` calls.
>   - Add properties: `sensor_derived_groups`, `last_modbus_request`, and `device_identification` (plus expose `last_modbus_success`).
> - **Tests (`tests/test_modbus_controller.py`)**:
>   - Update expectations to assert `device_id` param in read calls.
>   - Add `TestModbusControllerProperties` covering new properties and `close_connection` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2163a8408b768b7e87685d6c65d0271b00f3c1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace `slave` with `device_id` in read calls

- Add controller properties: `sensor_derived_groups`, `last_modbus_request`, `device_identification`

- Update tests to assert `device_id` parameter

- Add unit tests for new properties and `close_connection`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modbus_controller.py</strong><dd><code>Refactor modbus read methods and add properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/modbus_controller.py

<ul><li>Replace <code>slave</code> with <code>device_id</code> in read_input and holding register calls<br> <li> Remove unused serial port config imports<br> <li> Add properties: <code>sensor_derived_groups</code>, <code>last_modbus_request</code>, <br><code>device_identification</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/304/files#diff-e230937b651240e2eb7a7c8fd2f5c2db9521105ae3be0352f3439850b9089f1e">+26/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_modbus_controller.py</strong><dd><code>Update tests for device_id and new properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_modbus_controller.py

<ul><li>Update read register tests to expect <code>device_id</code> argument<br> <li> Add <code>TestModbusControllerProperties</code> class with:<br>   - tests for sensor <br>and derived sensor groups<br>   - tests for <code>last_modbus_request</code>, <br><code>last_modbus_success</code>, <code>device_identification</code><br>   - test for <br><code>close_connection</code> behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/304/files#diff-0109f71532f05ee50b83547d0dccf3b6e957dad273c03f19fda70750c052a356">+79/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

