### PR TITLE
Support for larger Solis S6-EH3P (29.9-60)

### DIFF
--- a/custom_components/solis_modbus/data/solis_config.py
+++ b/custom_components/solis_modbus/data/solis_config.py
@@ -50,7 +50,7 @@ SOLIS_INVERTERS = [
                    features=[InverterFeature.SMART_PORT]),
     InverterConfig(model="S6-EH2P", wattage=[9600, 11400, 12000, 14000, 16000], phases=3, type=InverterType.HYBRID,
                    features=[InverterFeature.SMART_PORT]),
-    InverterConfig(model="S6-EH3P", wattage=[8000, 10000, 12000, 15000], phases=3, type=InverterType.HYBRID,
+    InverterConfig(model="S6-EH3P", wattage=[8000, 10000, 12000, 15000, 29900, 30000, 40000, 49000, 50000, 60000], phases=3, type=InverterType.HYBRID,
                    features=[InverterFeature.SMART_PORT]),
     InverterConfig(model="S6-EO1P", wattage=[4000, 5000], phases=1, type=InverterType.HYBRID,
                    features=[InverterFeature.SMART_PORT]),


### PR DESCRIPTION
## 🔄 Related Issues
Closes #338

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.

