### PR TITLE
Adjust Solis current max rounding to `10A`

### DIFF
--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -116,7 +116,7 @@ class SolisBaseSensor:
         try:
             new_max = max_default
             if self.unit_of_measurement == UnitOfElectricCurrent.AMPERE:
-                new_max = round((self.controller.inverter_config.wattage_chosen / 44) / 10) * 10
+                new_max = round((self.controller.inverter_config.wattage_chosen / 44) / 10) * 20
             elif self.unit_of_measurement == UnitOfPower.WATT:
                 new_max = self.controller.inverter_config.wattage_chosen
             elif self.unit_of_measurement == UnitOfPower.KILO_WATT:

--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -116,7 +116,7 @@ class SolisBaseSensor:
         try:
             new_max = max_default
             if self.unit_of_measurement == UnitOfElectricCurrent.AMPERE:
-                new_max = round((self.controller.inverter_config.wattage_chosen / 44) / 5) * 5
+                new_max = round((self.controller.inverter_config.wattage_chosen / 44) / 10) * 10
             elif self.unit_of_measurement == UnitOfPower.WATT:
                 new_max = self.controller.inverter_config.wattage_chosen
             elif self.unit_of_measurement == UnitOfPower.KILO_WATT:


### PR DESCRIPTION
### **User description**
… calculation

## 🔄 Related Issues
Closes #351
## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Enhancement


___

### **Description**
- Round current max to nearest `10A`

- Update amp limit calculation logic

- Leave watt and kW limits unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configured inverter wattage"]
  B["Ampere max calculation"]
  C["Rounded to nearest 10A"]
  D["Sensor max value"]
  A -- "feeds" --> B
  B -- "now uses" --> C
  C -- "sets" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_base_sensor.py</strong><dd><code>Revise ampere max rounding behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_base_sensor.py

<ul><li>Change ampere max rounding from <code>5A</code> to <code>10A</code><br> <li> Update <code>adjust_max</code> current limit calculation<br> <li> Keep watt and kilowatt branches unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/361/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

