### PR TITLE
Add derived DC power sensors for string inverters

### DIFF
--- a/custom_components/solis_modbus/sensor_data/string_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/string_sensors.py
@@ -592,4 +592,41 @@ string_sensors = [
     },
 ]
 
-string_sensors_derived = []
+string_sensors_derived = [
+    {
+        "name": "DC Power 1",
+        "unique": "solis_modbus_dc_power_1",
+        "device_class": SensorDeviceClass.POWER,
+        "multiplier": 0.1,
+        "unit_of_measurement": UnitOfPower.WATT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "register": ["3021", "3022"],
+    },
+    {
+        "name": "DC Power 2",
+        "unique": "solis_modbus_dc_power_2",
+        "device_class": SensorDeviceClass.POWER,
+        "multiplier": 0.1,
+        "unit_of_measurement": UnitOfPower.WATT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "register": ["3023", "3024"],
+    },
+    {
+        "name": "DC Power 3",
+        "unique": "solis_modbus_dc_power_3",
+        "device_class": SensorDeviceClass.POWER,
+        "multiplier": 0.1,
+        "unit_of_measurement": UnitOfPower.WATT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "register": ["3025", "3026"],
+    },
+    {
+        "name": "DC Power 4",
+        "unique": "solis_modbus_dc_power_4",
+        "device_class": SensorDeviceClass.POWER,
+        "multiplier": 0.1,
+        "unit_of_measurement": UnitOfPower.WATT,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "register": ["3027", "3028"],
+    },
+]

--- a/custom_components/solis_modbus/sensors/solis_derived_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_derived_sensor.py
@@ -115,6 +115,12 @@ class SolisDerivedSensor(RestoreSensor, SensorEntity):
                 r2_value = self._received_values[self._register[1]] * self.base_sensor.multiplier
                 new_value = round(r1_value * r2_value)
 
+            # String inverter: DC Voltage [n] × DC Current [n] (registers 3021–3028, protocol Ver19)
+            if 3021 in self._register or 3023 in self._register or 3025 in self._register or 3027 in self._register:
+                r1_value = self._received_values[self._register[0]] * self.base_sensor.multiplier
+                r2_value = self._received_values[self._register[1]] * self.base_sensor.multiplier
+                new_value = round(r1_value * r2_value)
+
             if 33079 in self._register or 33080 in self._register or 33081 in self._register or 33082 in self._register:
                 active_power = self.base_sensor.convert_value([self._received_values[self._register[0]], self._received_values[self._register[1]]])
                 reactive_power = self.base_sensor.convert_value([self._received_values[self._register[2]], self._received_values[self._register[3]]])

--- a/tests/test_derived_sensor.py
+++ b/tests/test_derived_sensor.py
@@ -74,7 +74,7 @@ def test_derived_sensor_string_dc_power(hass: HomeAssistant, mock_base_sensor):
     with patch.object(sensor, "schedule_update_ha_state"):
         sensor.handle_modbus_update(event_data)
 
-    assert sensor.native_value == 2000  # 40 * 5 W
+    assert sensor.native_value == 200  # 40 * 5 W * 0.1
 
 
 def test_derived_sensor_wrong_controller(hass: HomeAssistant, mock_base_sensor):

--- a/tests/test_derived_sensor.py
+++ b/tests/test_derived_sensor.py
@@ -61,6 +61,22 @@ def test_derived_sensor_dc_power(hass: HomeAssistant, mock_base_sensor):
     assert sensor.native_value == 2000
 
 
+def test_derived_sensor_string_dc_power(hass: HomeAssistant, mock_base_sensor):
+    """String inverter DC power: raw V and A each scaled ×0.1, product in watts."""
+    mock_base_sensor.registrars = [3021, 3022]
+    mock_base_sensor.multiplier = 0.1
+    sensor = SolisDerivedSensor(hass, mock_base_sensor)
+
+    sensor._received_values[3021] = 400  # 40.0 V
+
+    event_data = {REGISTER: 3022, VALUE: 50, CONTROLLER: "1.2.3.4", SLAVE: 1}
+
+    with patch.object(sensor, "schedule_update_ha_state"):
+        sensor.handle_modbus_update(event_data)
+
+    assert sensor.native_value == 2000  # 40 * 5 W
+
+
 def test_derived_sensor_wrong_controller(hass: HomeAssistant, mock_base_sensor):
     sensor = SolisDerivedSensor(hass, mock_base_sensor)
 


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #281 (if applicable)

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add derived string inverter DC power sensors

- Calculate watts from DC voltage/current registers

- Cover string DC power derivation with tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  regs["String inverter DC registers 3021-3028"]
  calc["Derived sensor multiplies V × A"]
  sensors["DC Power 1-4 sensors"]
  tests["Derived sensor test coverage"]

  regs -- "provide raw values" --> calc
  calc -- "publishes watts" --> sensors
  calc -- "validated by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>string_sensors.py</strong><dd><code>Add derived DC power sensor definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/string_sensors.py

<ul><li>Add four derived sensors: <code>DC Power 1</code> to <code>DC Power 4</code><br> <li> Define unique IDs for each string DC power sensor<br> <li> Configure power metadata with watt units and measurement state<br> <li> Map each sensor to paired DC voltage/current registers <code>3021</code>-<code>3028</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/365/files#diff-31de825d31f0fe277a133520e0615a4b6683bca106be79dfc95aff96538b44d1">+38/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>solis_derived_sensor.py</strong><dd><code>Support DC power calculation for strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_derived_sensor.py

<ul><li>Add derived calculation for string inverter DC power<br> <li> Detect register pairs starting at <code>3021</code>, <code>3023</code>, <code>3025</code>, <code>3027</code><br> <li> Scale both raw values by multiplier, then multiply<br> <li> Round the computed watt value before publishing</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/365/files#diff-dcaabc83e45e8f85ccb48d3e876870a70460908d41623ab7fa6161dcb953521b">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_derived_sensor.py</strong><dd><code>Test derived string DC power sensor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_derived_sensor.py

<ul><li>Add test for string inverter DC power derivation<br> <li> Verify scaled <code>3021</code> and <code>3022</code> values produce watts<br> <li> Confirm computed native value equals <code>2000</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/365/files#diff-afb9ab2b3ee56e31be7a4894d7aaa6ef99903bf3275bd55de029067eaeb68246">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

