### PR TITLE
Improve parallel controller cache isolation and link coordination

### DIFF
--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -155,9 +155,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN].setdefault(CONTROLLER, {})
 
     # Stagger additional config entries on the same Modbus link so two inverters do not hammer the logger at once.
-    existing_same_link = sum(
-        1 for c in hass.data[DOMAIN][CONTROLLER].values() if getattr(c, "connection_id", None) == connection_id
-    )
+    existing_same_link = sum(1 for c in hass.data[DOMAIN][CONTROLLER].values() if getattr(c, "connection_id", None) == connection_id)
     if existing_same_link:
         delay_s = min(1.5 * existing_same_link, 5.0)
         _LOGGER.debug(

--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -154,6 +154,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN].setdefault(CONTROLLER, {})
 
+    # Stagger additional config entries on the same Modbus link so two inverters do not hammer the logger at once.
+    existing_same_link = sum(
+        1 for c in hass.data[DOMAIN][CONTROLLER].values() if getattr(c, "connection_id", None) == connection_id
+    )
+    if existing_same_link:
+        delay_s = min(1.5 * existing_same_link, 5.0)
+        _LOGGER.debug(
+            "Staggering startup: %s existing controller(s) on %s, waiting %.1fs",
+            existing_same_link,
+            connection_id,
+            delay_s,
+        )
+        await asyncio.sleep(delay_s)
+
     _LOGGER.info(f"Loaded Solis Modbus Integration ({connection_type}) with Model: {config.get('model')}")
 
     # ... (Config extraction ...) ...

--- a/custom_components/solis_modbus/client_manager.py
+++ b/custom_components/solis_modbus/client_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 
 from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
 
@@ -12,7 +13,7 @@ class ModbusClientManager:
     _instance = None
 
     def __init__(self):
-        # Key: connection_id (str), Value: {'client': AsyncModbusTcpClient|AsyncModbusSerialClient, 'ref_count': int, 'lock': asyncio.Lock, 'type': str}
+        # Key: connection_id (str), Value: client entry including shared inter-frame timing for all slaves on that link.
         self._clients: dict[str, dict] = {}
 
     @classmethod
@@ -27,7 +28,13 @@ class ModbusClientManager:
         if key not in self._clients:
             _LOGGER.debug(f"Creating new Modbus TCP client for {host}:{port}")
             client = AsyncModbusTcpClient(host=host, port=port, timeout=5, retries=5)
-            self._clients[key] = {"client": client, "ref_count": 0, "lock": asyncio.Lock(), "type": CONN_TYPE_TCP}
+            self._clients[key] = {
+                "client": client,
+                "ref_count": 0,
+                "lock": asyncio.Lock(),
+                "type": CONN_TYPE_TCP,
+                "last_modbus_request": 0.0,
+            }
 
         self._clients[key]["ref_count"] += 1
         _LOGGER.debug(f"TCP client ref count for {host}:{port} is now {self._clients[key]['ref_count']}")
@@ -39,7 +46,13 @@ class ModbusClientManager:
         if key not in self._clients:
             _LOGGER.debug(f"Creating new Modbus Serial client for {serial_port} (baudrate={baudrate})")
             client = AsyncModbusSerialClient(port=serial_port, baudrate=baudrate, bytesize=bytesize, parity=parity, stopbits=stopbits, timeout=5)
-            self._clients[key] = {"client": client, "ref_count": 0, "lock": asyncio.Lock(), "type": CONN_TYPE_SERIAL}
+            self._clients[key] = {
+                "client": client,
+                "ref_count": 0,
+                "lock": asyncio.Lock(),
+                "type": CONN_TYPE_SERIAL,
+                "last_modbus_request": 0.0,
+            }
 
         self._clients[key]["ref_count"] += 1
         _LOGGER.debug(f"Serial client ref count for {serial_port} is now {self._clients[key]['ref_count']}")
@@ -71,6 +84,25 @@ class ModbusClientManager:
         if connection_id in self._clients:
             return self._clients[connection_id]["lock"]
         return None
+
+    def get_last_modbus_request(self, connection_id: str) -> float:
+        """Monotonic time of last inter-frame wait start for this link (shared across Modbus slaves)."""
+        if connection_id in self._clients:
+            return float(self._clients[connection_id].get("last_modbus_request", 0.0))
+        return 0.0
+
+    async def inter_frame_wait(self, connection_id: str, is_write: bool = False) -> None:
+        """Minimum spacing between Modbus operations on one TCP/serial link, across all controllers sharing it."""
+        if connection_id not in self._clients:
+            return
+        delay_ms = 100 if is_write else 50
+        entry = self._clients[connection_id]
+        current_time = time.perf_counter()
+        last = float(entry.get("last_modbus_request", 0.0))
+        elapsed = (current_time - last) * 1000
+        if elapsed < delay_ms:
+            await asyncio.sleep((delay_ms - elapsed) / 1000)
+        entry["last_modbus_request"] = time.perf_counter()
 
     def release_client(self, connection_id: str):
         """Release a client and clean up if no more references."""

--- a/custom_components/solis_modbus/data_retrieval.py
+++ b/custom_components/solis_modbus/data_retrieval.py
@@ -255,7 +255,7 @@ class DataRetrieval:
                         reg = start_register + i
                         _LOGGER.debug(f"block {start_register}, register {reg} has value {value}")
                         corrected_value = self.spike_filtering(reg, value)
-                        cache_save(self.hass, reg, corrected_value)
+                        cache_save(self.hass, self.controller, reg, corrected_value)
                         notify_register_update(self.hass, self.controller, reg, corrected_value)
 
                     if sensor_group.poll_speed == PollSpeed.ONCE:
@@ -276,7 +276,7 @@ class DataRetrieval:
     # https://github.com/Pho3niX90/solis_modbus/issues/138
     def spike_filtering(self, register: int, value: int):
         """Filter short-lived implausible readings for known noisy registers."""
-        cached_value = cache_get(self.hass, register)
+        cached_value = cache_get(self.hass, self.controller, register)
         if register not in self._spike_counter:
             self._spike_counter[register] = 0
 

--- a/custom_components/solis_modbus/helpers.py
+++ b/custom_components/solis_modbus/helpers.py
@@ -129,12 +129,21 @@ def decode_inverter_model(hex_value):
     return protocol_version, model_description
 
 
-def cache_save(hass: HomeAssistant, register: str | int, value):
-    hass.data[DOMAIN][VALUES][str(register)] = value
+def register_cache_key(controller, register: str | int) -> str:
+    """Build a register cache key scoped to Modbus link + slave (parallel inverters on one logger)."""
+    conn = getattr(controller, "connection_id", None)
+    if not isinstance(conn, str):
+        conn = str(getattr(controller, "host", "") or "")
+    slave = int(getattr(controller, "device_id", 1))
+    return f"{conn}|{slave}|{register}"
 
 
-def cache_get(hass: HomeAssistant, register: str | int):
-    return hass.data[DOMAIN][VALUES].get(str(register), None)
+def cache_save(hass: HomeAssistant, controller, register: str | int, value):
+    hass.data[DOMAIN][VALUES][register_cache_key(controller, register)] = value
+
+
+def cache_get(hass: HomeAssistant, controller, register: str | int):
+    return hass.data[DOMAIN][VALUES].get(register_cache_key(controller, register), None)
 
 
 def set_controller(hass: HomeAssistant, controller, config_entry: ConfigEntry):

--- a/custom_components/solis_modbus/manifest.json
+++ b/custom_components/solis_modbus/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/Pho3niX90/solis_modbus/issues",
   "quality_scale": "silver",
   "requirements": ["pymodbus>=3.11.1"],
-  "version": "4.1.1"
+  "version": "4.1.2"
 }

--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import time
 from datetime import UTC, datetime
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -76,8 +75,9 @@ class ModbusController:
         self.serial_number = serial_number
         self.identification = identification
 
-        # Use ModbusClientManager to get shared client and lock
-        manager = ModbusClientManager.get_instance()
+        # Use ModbusClientManager to get shared client, lock, and per-link timing shared by all slaves.
+        self._client_manager = ModbusClientManager.get_instance()
+        manager = self._client_manager
 
         # Connection-specific setup
         if connection_type == CONN_TYPE_TCP:
@@ -118,7 +118,6 @@ class ModbusController:
 
         # Modbus Write Queue
         self.write_queue = asyncio.Queue()
-        self._last_modbus_request = 0
         self._last_modbus_success = datetime.now(UTC)
 
     async def process_write_queue(self):
@@ -184,7 +183,7 @@ class ModbusController:
                     _LOGGER.error(f"({self.host}.{self.device_id}) Failed to write holding register {register} with value {value}: {result}")
                     return None
 
-                cache_save(self.hass, int_register, result.registers[0])
+                cache_save(self.hass, self, int_register, result.registers[0])
                 notify_register_update(self.hass, self, int_register, result.registers[0])
 
                 return result
@@ -226,7 +225,7 @@ class ModbusController:
 
                 for i, value in enumerate(values):
                     reg_addr = start_register + i
-                    cache_save(self.hass, reg_addr, value)
+                    cache_save(self.hass, self, reg_addr, value)
                     notify_register_update(self.hass, self, reg_addr, value)
                 return result
         except Exception as e:
@@ -258,29 +257,8 @@ class ModbusController:
         await self.write_queue.put((start_register, values, True))
 
     async def inter_frame_wait(self, is_write=False):
-        """Implements inter-frame delay to respect Modbus timing requirements.
-
-        This method calculates the time since the last Modbus request and adds
-        a delay if necessary to ensure proper spacing between operations.
-
-        Args:
-            is_write (bool): If True, uses a longer delay for write operations.
-
-        Returns:
-            None
-        """
-        # Minimum delay between Modbus operations (milliseconds)
-        # Write operations get slightly longer delays for safety
-        delay_ms = 100 if is_write else 50
-
-        current_time = time.perf_counter()
-        elapsed = (current_time - self._last_modbus_request) * 1000  # Convert to ms
-
-        if elapsed < delay_ms:
-            sleep_time = (delay_ms - elapsed) / 1000
-            await asyncio.sleep(sleep_time)
-
-        self._last_modbus_request = time.perf_counter()
+        """Spacing between Modbus frames on this link (shared across parallel inverters on the same host:port)."""
+        await self._client_manager.inter_frame_wait(self.connection_id, is_write=is_write)
 
     async def _async_read_input_register_raw(self, register, count):
         """Raw read input registers without connection check (internal use)."""
@@ -376,26 +354,34 @@ class ModbusController:
         if self.connected():
             return True
 
-        try:
-            await self.client.connect()
-            if self.connected():
-                _LOGGER.info(f"✅ ({self.host}.{self.device_id}) Connected to Modbus device")
-                self.connect_failures = 0
+        async def _try_connect() -> bool:
+            try:
+                await self.client.connect()
+                if self.connected():
+                    _LOGGER.info(f"✅ ({self.host}.{self.device_id}) Connected to Modbus device")
+                    self.connect_failures = 0
 
-                if self.serial_number is None:
-                    _LOGGER.info(f"serial got from device: {self.serial_number}")
-                else:
-                    _LOGGER.info(f"serial got from cache: {self.serial_number}")
+                    if self.serial_number is None:
+                        _LOGGER.info(f"serial got from device: {self.serial_number}")
+                    else:
+                        _LOGGER.info(f"serial got from cache: {self.serial_number}")
 
-                return True
-            else:
+                    return True
                 self.connect_failures += 1
                 _LOGGER.debug(f"⚠️ ({self.host}:{self.port}.{self.device_id}) Connection attempt {self.connect_failures} failed")
                 return False
-        except Exception as e:
-            self.connect_failures += 1
-            _LOGGER.debug(f"❌ ({self.host}.{self.device_id}) Connection error (attempt {self.connect_failures}): {e}")
-            return False
+            except Exception as e:
+                self.connect_failures += 1
+                _LOGGER.debug(f"❌ ({self.host}.{self.device_id}) Connection error (attempt {self.connect_failures}): {e}")
+                return False
+
+        lock = self.poll_lock
+        if lock:
+            async with lock:
+                if self.connected():
+                    return True
+                return await _try_connect()
+        return await _try_connect()
 
     def connected(self):
         """Checks if the Modbus client is currently connected.
@@ -481,9 +467,9 @@ class ModbusController:
         """Gets the timestamp of the last Modbus request.
 
         Returns:
-            float: The timestamp of the last Modbus request (from time.monotonic()).
+            float: Shared per-link timestamp from time.perf_counter() after the last inter-frame wait.
         """
-        return self._last_modbus_request
+        return self._client_manager.get_last_modbus_request(self.connection_id)
 
     @property
     def last_modbus_success(self):

--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -138,7 +138,7 @@ class SolisBaseSensor:
 
     @property
     def get_raw_values(self):
-        return [cache_get(self.hass, reg) for reg in self.registrars]
+        return [cache_get(self.hass, self.controller, reg) for reg in self.registrars]
 
     @property
     def get_value(self):

--- a/custom_components/solis_modbus/sensors/solis_binary_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_binary_sensor.py
@@ -81,7 +81,7 @@ class SolisBinaryEntity(RestoreEntity, SwitchEntity):
             value = updated_value
 
             if value is None:
-                value = cache_get(self._hass, self._register)
+                value = cache_get(self._hass, self._modbus_controller, self._register)
 
             self._attr_available = True
             if self._bit_position is not None:
@@ -113,7 +113,7 @@ class SolisBinaryEntity(RestoreEntity, SwitchEntity):
     def set_register_bit(self, value: bool):
         """Set or clear a specific bit in the Modbus register, enforcing dependencies and conflicts."""
         controller = self._modbus_controller
-        current_register_value: int = cache_get(self._hass, self._register)
+        current_register_value: int = cache_get(self._hass, self._modbus_controller, self._register)
 
         new_register_value = current_register_value
 
@@ -153,7 +153,7 @@ class SolisBinaryEntity(RestoreEntity, SwitchEntity):
         if current_register_value != new_register_value and controller.connected():
             target_register = self._write_register
             self._hass.create_task(controller.async_write_holding_register(target_register, new_register_value))
-            cache_save(self._hass, target_register, new_register_value)
+            cache_save(self._hass, self._modbus_controller, target_register, new_register_value)
 
         self._attr_is_on = value
         self._attr_available = True

--- a/custom_components/solis_modbus/sensors/solis_number_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_number_sensor.py
@@ -68,7 +68,7 @@ class SolisNumberEntity(RestoreNumber, NumberEntity):
     def adjust_min_max_step(self, min_wanted: float | None, max_wanted: float | None, step_wanted: float | None):
         # float(43016) & equalization(43017) voltages, and rated capacity(43019)
         if 43016 in self._register or 43017 in self._register or 43019 in self._register:
-            installed_battery = cache_get(self.hass, 43009)
+            installed_battery = cache_get(self.hass, self.base_sensor.controller, 43009)
 
             if is_number(installed_battery):
                 # only supported with a user defined battery

--- a/custom_components/solis_modbus/sensors/solis_select_entity.py
+++ b/custom_components/solis_modbus/sensors/solis_select_entity.py
@@ -23,7 +23,7 @@ class SolisSelectEntity(RestoreEntity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        reg_cache = cache_get(self._hass, self._register)
+        reg_cache = cache_get(self._hass, self._modbus_controller, self._register)
         if reg_cache is None:
             return
 
@@ -73,7 +73,7 @@ class SolisSelectEntity(RestoreEntity, SelectEntity):
     def set_register_bit(self, on_value, bit_position, conflicts_with, requires):
         """Set or clear a specific bit in the Modbus register."""
         controller = self._modbus_controller
-        current_register_value: int = cache_get(self._hass, self._register)
+        current_register_value: int = cache_get(self._hass, self._modbus_controller, self._register)
 
         if bit_position is not None:
             # Clear conflicts
@@ -95,7 +95,7 @@ class SolisSelectEntity(RestoreEntity, SelectEntity):
         # we only want to write when values has changed. After, we read the register again to make sure it applied.
         if current_register_value != new_register_value and controller.connected():
             self._hass.create_task(controller.async_write_holding_register(self._register, new_register_value))
-            cache_save(self._hass, self._register, new_register_value)
+            cache_save(self._hass, self._modbus_controller, self._register, new_register_value)
         self._attr_available = True
 
 

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -85,7 +85,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
         if updated_register in self._register:
             # Causes issues with grid inverters going offline, and messing up energy dashboard
             if self.base_sensor.controller.inverter_config.type == InverterType.GRID and 3014 == updated_register:
-                if cache_get(self.hass, 3043) == 2:
+                if cache_get(self.hass, self.base_sensor.controller, 3043) == 2:
                     self._attr_native_value = 0
                     self.schedule_update_ha_state()
                     self._last_update = datetime.now(UTC).astimezone()

--- a/custom_components/solis_modbus/time.py
+++ b/custom_components/solis_modbus/time.py
@@ -103,8 +103,8 @@ class SolisTimeEntity(RestoreSensor, TimeEntity):
             self._received_values[updated_register] = updated_value
 
             if updated_value is not None:
-                hour = cache_get(self.hass, self._register)
-                minute = cache_get(self.hass, self._register + 1)
+                hour = cache_get(self._hass, self._modbus_controller, self._register)
+                minute = cache_get(self._hass, self._modbus_controller, self._register + 1)
 
                 if hour is not None and minute is not None:
                     hour, minute = int(hour), int(minute)

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch
 
 from custom_components.solis_modbus.client_manager import ModbusClientManager
@@ -72,6 +73,23 @@ class TestModbusClientManager(unittest.TestCase):
     def test_release_non_existent_client(self):
         # Should not raise
         self.manager.release_client("9.9.9.9:502")
+
+
+class TestModbusClientManagerInterFrame(IsolatedAsyncioTestCase):
+    def setUp(self):
+        ModbusClientManager._instance = None
+        self.manager = ModbusClientManager.get_instance()
+
+    def tearDown(self):
+        ModbusClientManager._instance = None
+
+    @patch("custom_components.solis_modbus.client_manager.AsyncModbusTcpClient")
+    async def test_inter_frame_wait_updates_shared_timestamp(self, mock_client_cls):
+        mock_client_cls.return_value = MagicMock()
+        self.manager.get_tcp_client("1.2.3.4", 502)
+        self.assertEqual(0.0, self.manager.get_last_modbus_request("1.2.3.4:502"))
+        await self.manager.inter_frame_wait("1.2.3.4:502", is_write=False)
+        self.assertGreater(self.manager.get_last_modbus_request("1.2.3.4:502"), 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_modbus_controller.py
+++ b/tests/test_modbus_controller.py
@@ -36,6 +36,8 @@ class TestModbusControllerTCP(IsolatedAsyncioTestCase):
         # Mock TCP Client
         self.mock_client = MagicMock()
         self.mock_manager.get_tcp_client.return_value = self.mock_client
+        self.mock_manager.inter_frame_wait = AsyncMock()
+        self.mock_manager.get_last_modbus_request = MagicMock(return_value=0.0)
 
         # Mock Lock
         self.mock_lock = MagicMock()
@@ -212,6 +214,8 @@ class TestModbusControllerSerial(IsolatedAsyncioTestCase):
         # Mock Serial Client
         self.mock_client = MagicMock()
         self.mock_manager.get_serial_client.return_value = self.mock_client
+        self.mock_manager.inter_frame_wait = AsyncMock()
+        self.mock_manager.get_last_modbus_request = MagicMock(return_value=0.0)
 
         # Mock Lock
         self.mock_lock = MagicMock()
@@ -480,6 +484,8 @@ class TestModbusControllerProperties(unittest.TestCase):
 
         self.mock_manager.get_tcp_client.return_value = MagicMock()
         self.mock_manager.get_client_lock.return_value = MagicMock()
+        self.mock_manager.inter_frame_wait = AsyncMock()
+        self.mock_manager.get_last_modbus_request = MagicMock(return_value=0.0)
 
         self.sensor_groups = [MagicMock()]
         self.derived_sensors = [MagicMock()]

--- a/tests/test_unique_id_generator.py
+++ b/tests/test_unique_id_generator.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from custom_components.solis_modbus.const import DOMAIN
-from custom_components.solis_modbus.helpers import unique_id_generator
+from custom_components.solis_modbus.helpers import register_cache_key, unique_id_generator
 
 
 class TestUniqueIdGenerator(unittest.TestCase):
@@ -49,6 +49,19 @@ class TestUniqueIdGenerator(unittest.TestCase):
         unique_id = unique_id_generator(self.controller, self.entity_def.get("unique", "reserve"))
         expected_id = f"{DOMAIN}_SN123456_test_sensor"
         self.assertEqual(unique_id, expected_id, "Serial Number should take precedence over Identification")
+
+
+class TestRegisterCacheKey(unittest.TestCase):
+    def test_parallel_slaves_distinct(self):
+        c1 = MagicMock()
+        c1.connection_id = "10.0.0.1:502"
+        c1.device_id = 1
+        c2 = MagicMock()
+        c2.connection_id = "10.0.0.1:502"
+        c2.device_id = 2
+        self.assertEqual(register_cache_key(c1, 33139), "10.0.0.1:502|1|33139")
+        self.assertEqual(register_cache_key(c2, 33139), "10.0.0.1:502|2|33139")
+        self.assertNotEqual(register_cache_key(c1, 33139), register_cache_key(c2, 33139))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### **User description**
- Introduced `register_cache_key` for controller-scoped Modbus cache handling.
- Added shared inter-frame timing logic via `ModbusClientManager`.
- Updated cache access (`cache_get` and `cache_save`) to include controller context.
- Implemented staggered startup for parallel controllers on the same Modbus link.
- Added and expanded unit tests for caching and inter-frame logic.
- Bumped integration version to `4.1.2`.

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Scope register cache per controller

- Share Modbus timing across links

- Stagger startup and lock reconnects

- Add cache and timing tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ctrl["Parallel inverter controllers"]
  cache["Controller-scoped register cache"]
  timing["Shared inter-frame timing"]
  startup["Staggered same-link startup"]
  link["Shared Modbus link"]
  ctrl -- "store values in" --> cache
  ctrl -- "coordinate requests with" --> timing
  startup -- "reduces contention on" --> link
  timing -- "applies spacing on" --> link
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Stagger startup for controllers sharing links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-90c384b3c13c51777899c6bb6f69f01762e31d9fed1da9933a765b6e6fe60be3">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client_manager.py</strong><dd><code>Add shared inter-frame timing tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-0d0cc9dc21fb88eb9686bc313538e7ae7444dcb613992cff1d5e1af2c5289ab0">+35/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>modbus_controller.py</strong><dd><code>Centralize link timing and guarded connects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-e230937b651240e2eb7a7c8fd2f5c2db9521105ae3be0352f3439850b9089f1e">+32/-46</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>data_retrieval.py</strong><dd><code>Scope polling cache access by controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-80ac627de8506ebe8f2aca62b1581ad9f9a89d3002dacae88dc14fbc31218927">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.py</strong><dd><code>Introduce controller-specific register cache keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-62575804e6e6479bc99910af8f216c62e76af4bc818fc0a93b80c8726b6b65be">+13/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>solis_base_sensor.py</strong><dd><code>Read cached register values per controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>solis_binary_sensor.py</strong><dd><code>Isolate binary sensor cache reads writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-d39102b709446949c1462374be814672bb33e644165cf47272371f7e7da354e1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>solis_number_sensor.py</strong><dd><code>Use controller-scoped battery cache lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-12de5d2a79db4982e540517bacb61591ae1560a31897d2b123b51a5be1cd2b24">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>solis_select_entity.py</strong><dd><code>Scope select entity cache interactions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-5148bff83209796b04c787f8218342b1776f9de43adf16aebaa99808bdfe6edc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>solis_sensor.py</strong><dd><code>Use controller-specific cached status reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-9fd594ef705e5a1c42382d7e43cf97b0914f00cf6d9f036eca58bbd755792aae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>time.py</strong><dd><code>Fix time entity cache source context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-985db4ef648e7be8a644c569c39b8c052135ec8eea28030589fe3693558a2022">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_client_manager.py</strong><dd><code>Add shared inter-frame timing test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-8786c8a6b9d269c48f1e5ed2f7c715d2d3ffeb8bc26365488460db4e163b2a82">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_modbus_controller.py</strong><dd><code>Mock new manager timing accessors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-0109f71532f05ee50b83547d0dccf3b6e957dad273c03f19fda70750c052a356">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_unique_id_generator.py</strong><dd><code>Test distinct cache keys for slaves</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-003df7169e6ca659d01cd3512a7da76d8bdf35c9e1f32d5794b98bd611a1176b">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump integration version to `4.1.2`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/369/files#diff-cd118a6e8c28d762686f925f1dcd17c9f7075b8c31548d08c7af2120cefb5753">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

