### PR TITLE
Fix signed decoding for meter power factor

### DIFF
--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -1197,6 +1197,7 @@ hybrid_sensors = [
                 "multiplier": 0.01,
                 "unit_of_measurement": PERCENTAGE,
                 "state_class": SensorStateClass.MEASUREMENT,
+                "data_type": DataType.S16,
             },
             {
                 "name": "Meter Grid Frequency",


### PR DESCRIPTION
### **User description**
## Summary

Register 33281 (Meter Power Factor) is a signed 16-bit integer but was missing `data_type: DataType.S16`, causing it to be read as unsigned.

When the power factor is slightly negative (e.g. a near-unity leading condition, or when solar generation closely matches load and net grid exchange is small), the two's complement representation gives a raw value above 32767. Without the signed flag this is used as-is, producing nonsensical readings such as **655%** instead of the correct value.

**Example:**
- Raw register value: `0xFFF0` = 65520 (unsigned) → **655.2%** ❌
- With S16 decoding: 65520 − 65536 = −16 → −16 × 0.01 = **−0.16%** ✓

## Root cause

- PR #284 introduced register 33281 without `data_type: S16`.
- PR #335 introduced the S16 decoding infrastructure and applied it to temperature/battery current registers, but register 33281 was not updated at that time.

## Fix

Add `"data_type": DataType.S16` to the Meter Power Factor sensor definition. `DataType` is already imported in `hybrid_sensors.py` and the decoding path in `solis_base_sensor.py` is already in place.

## Test plan

- [ ] Confirm sensor reports a value in the range −100% to 100% after restart
- [ ] Verify readings are consistent with meter reactive power and apparent power sensors


___

### **PR Type**
Bug fix


___

### **Description**
- Mark meter power factor as `S16`

- Fix negative `33281` decoding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Meter Power Factor sensor"]
  B["data_type: DataType.S16"]
  C["Signed 16-bit decoding"]
  D["Correct negative power factor values"]
  A -- "adds" --> B
  B -- "enables" --> C
  C -- "produces" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid_sensors.py</strong><dd><code>Mark meter power factor as signed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/hybrid_sensors.py

<ul><li>Add <code>data_type: DataType.S16</code> to <code>Meter Power Factor</code><br> <li> Update register <code>33281</code> to use signed decoding<br> <li> Prevent invalid large positive power factor readings</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/373/files#diff-540e84e48ae8dd4a164fe7fa970bf88a7375c29588090e2cfe4b8bf7ff16518f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

