### PR TITLE
Fix signed meter PF decoding and disconnected Modbus handling

### DIFF
--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -171,7 +171,14 @@ class ModbusController:
             Exception: If there is an error during the write operation.
         """
         try:
-            await self.connect()
+            if not await self.connect():
+                _LOGGER.debug(
+                    "(%s.%s) Skipping write holding register %s: Modbus client not connected",
+                    self.host,
+                    self.device_id,
+                    register,
+                )
+                return None
             async with self.poll_lock:
                 await self.inter_frame_wait(is_write=True)  # Delay before write
                 int_value = int(value)
@@ -213,7 +220,15 @@ class ModbusController:
             Exception: If there is an error during the write operation.
         """
         try:
-            await self.connect()
+            if not await self.connect():
+                _LOGGER.debug(
+                    "(%s.%s) Skipping write holding registers %s-%s: Modbus client not connected",
+                    self.host,
+                    self.device_id,
+                    start_register,
+                    start_register + len(values) - 1,
+                )
+                return None
             async with self.poll_lock:
                 await self.inter_frame_wait(is_write=True)  # Delay before write
 
@@ -298,7 +313,15 @@ class ModbusController:
     async def async_read_input_registers_with_exception(self, register: int, count: int) -> tuple[list[int] | None, int | None]:
         """Like async_read_input_register but returns (registers, exception_code) for recoverable-read logic."""
         try:
-            await self.connect()
+            if not await self.connect():
+                _LOGGER.debug(
+                    "(%s.%s) Skipping input read %s-%s: Modbus client not connected",
+                    self.host,
+                    self.device_id,
+                    register,
+                    register + count - 1,
+                )
+                return None, None
             return await self._async_read_input_register_raw_detailed(register, count, quiet=False)
         except Exception as e:
             _LOGGER.error(f"({self.host}.{self.device_id}) Exception while reading input registers starting at {register} (count={count}): {str(e)}")
@@ -318,7 +341,15 @@ class ModbusController:
             Exception: If there is an error during the read operation.
         """
         try:
-            await self.connect()
+            if not await self.connect():
+                _LOGGER.debug(
+                    "(%s.%s) Skipping input read %s-%s: Modbus client not connected",
+                    self.host,
+                    self.device_id,
+                    register,
+                    register + count - 1,
+                )
+                return None
             return await self._async_read_input_register_raw(register, count)
         except Exception as e:
             _LOGGER.error(f"({self.host}.{self.device_id}) Exception while reading input registers starting at {register} (count={count}): {str(e)}")
@@ -353,7 +384,15 @@ class ModbusController:
     async def async_read_holding_registers_with_exception(self, register: int, count: int) -> tuple[list[int] | None, int | None]:
         """Like async_read_holding_register but returns (registers, exception_code) for recoverable-read logic."""
         try:
-            await self.connect()
+            if not await self.connect():
+                _LOGGER.debug(
+                    "(%s.%s) Skipping holding read %s-%s: Modbus client not connected",
+                    self.host,
+                    self.device_id,
+                    register,
+                    register + count - 1,
+                )
+                return None, None
             return await self._async_read_holding_register_raw_detailed(register, count, quiet=False)
         except Exception as e:
             _LOGGER.error(f"({self.host}.{self.device_id}) Exception while reading holding registers starting at {register} (count={count}): {str(e)}")
@@ -373,7 +412,15 @@ class ModbusController:
             Exception: If there is an error during the read operation.
         """
         try:
-            await self.connect()
+            if not await self.connect():
+                _LOGGER.debug(
+                    "(%s.%s) Skipping holding read %s-%s: Modbus client not connected",
+                    self.host,
+                    self.device_id,
+                    register,
+                    register + count - 1,
+                )
+                return None
             return await self._async_read_holding_register_raw(register, count)
         except Exception as e:
             _LOGGER.error(f"({self.host}.{self.device_id}) Exception while reading holding registers starting at {register} (count={count}): {str(e)}")

--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -1195,6 +1195,7 @@ hybrid_sensors = [
                 "register": ["33281"],
                 "device_class": SensorDeviceClass.POWER_FACTOR,
                 "multiplier": 0.01,
+                "data_type": DataType.S16,
                 "unit_of_measurement": PERCENTAGE,
                 "state_class": SensorStateClass.MEASUREMENT,
             },

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -126,10 +126,13 @@ class SolisSensor(RestoreSensor, SensorEntity):
         """Fallback-Check: If no update for more than _WATCHDOG_TIMEOUT_MIN minutes, set values to 0 or unavailable"""
         now = datetime.now(UTC).astimezone()
         if (now - self._last_update > self._update_timeout) and self.poll_speed != PollSpeed.ONCE:
-            _LOGGER.debug(f"⚠️ No Modbus update for sensor {self._attr_name} in over {_WATCHDOG_TIMEOUT_MIN} minutes. Setting to 0.")
-            # self._attr_native_value = 0
-            self._attr_available = False  # Set attribute unavailable (if desired)
-            self.schedule_update_ha_state()
+            # Avoid repeated state writes/log spam while still disconnected/stale.
+            if self._attr_available:
+                _LOGGER.debug(
+                    f"⚠️ No Modbus update for sensor {self._attr_name} in over {_WATCHDOG_TIMEOUT_MIN} minutes. Marking as unavailable."
+                )
+                self._attr_available = False
+                self.schedule_update_ha_state()
 
     @property
     def device_info(self):

--- a/custom_components/solis_modbus/sensors/solis_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_sensor.py
@@ -128,9 +128,7 @@ class SolisSensor(RestoreSensor, SensorEntity):
         if (now - self._last_update > self._update_timeout) and self.poll_speed != PollSpeed.ONCE:
             # Avoid repeated state writes/log spam while still disconnected/stale.
             if self._attr_available:
-                _LOGGER.debug(
-                    f"⚠️ No Modbus update for sensor {self._attr_name} in over {_WATCHDOG_TIMEOUT_MIN} minutes. Marking as unavailable."
-                )
+                _LOGGER.debug(f"⚠️ No Modbus update for sensor {self._attr_name} in over {_WATCHDOG_TIMEOUT_MIN} minutes. Marking as unavailable.")
                 self._attr_available = False
                 self.schedule_update_ha_state()
 


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #374

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix signed meter power factor decoding

- Skip disconnected Modbus reads and writes

- Mark stale sensors unavailable only once


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pf["Meter Power Factor uses signed S16"]
  conn["Read/write paths verify connect()"]
  stale["Stale sensors update availability once"]
  result["Correct PF values and quieter failures"]

  pf -- "preserves negative values" --> result
  conn -- "skips disconnected operations" --> result
  stale -- "reduces repeated state churn" --> result
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modbus_controller.py</strong><dd><code>Guard Modbus operations when client disconnected</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/modbus_controller.py

<ul><li>Check <code>connect()</code> result before Modbus reads<br> <li> Check <code>connect()</code> result before Modbus writes<br> <li> Log skipped register ranges when disconnected<br> <li> Return <code>None</code> gracefully on disconnected access</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/376/files#diff-e230937b651240e2eb7a7c8fd2f5c2db9521105ae3be0352f3439850b9089f1e">+53/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid_sensors.py</strong><dd><code>Fix signed decoding for meter power factor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/hybrid_sensors.py

<ul><li>Set <code>Meter Power Factor</code> <code>data_type</code> to <code>DataType.S16</code><br> <li> Preserve signed power factor register values<br> <li> Keep percentage scaling with correct sign</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/376/files#diff-540e84e48ae8dd4a164fe7fa970bf88a7375c29588090e2cfe4b8bf7ff16518f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>solis_sensor.py</strong><dd><code>Reduce stale sensor log and update spam</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_sensor.py

<ul><li>Only mark stale sensors unavailable once<br> <li> Avoid repeated debug logs while disconnected<br> <li> Prevent repeated HA state update scheduling</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/376/files#diff-9fd594ef705e5a1c42382d7e43cf97b0914f00cf6d9f036eca58bbd755792aae">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

