### PR TITLE
Fix RC force mode timeout with companion writes

### DIFF
--- a/custom_components/solis_modbus/sensor_data/select_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/select_sensors.py
@@ -18,6 +18,13 @@ def get_select_sensors(inverter_config):
             {
                 "register": 43135,
                 "name": "RC Force Charge/Discharge",
+                # Solis firmware requires Forced Charge/Discharge (43135) to be enabled
+                # BEFORE the related setpoints and RC Timeout (43282) are written, otherwise
+                # the values do not latch (e.g. timeout falls back to ~5 minutes regardless
+                # of what is set). Re-writing the charge power (43136), discharge power
+                # (43129) and RC timeout (43282) from cache right after enabling realises
+                # the working "combo" sequence reported in issue #352.
+                "companion_writes": [43136, 43129, 43282],
                 "entities": [
                     {"name": "None", "on_value": 0},
                     {"name": "Solis RC Force Battery Charge", "on_value": 1},

--- a/custom_components/solis_modbus/sensors/solis_select_entity.py
+++ b/custom_components/solis_modbus/sensors/solis_select_entity.py
@@ -19,6 +19,7 @@ class SolisSelectEntity(RestoreEntity, SelectEntity):
 
         self._attr_options = [e["name"] for e in entity_definition["entities"]]
         self._attr_options_raw = entity_definition["entities"]
+        self._companion_writes = entity_definition.get("companion_writes") or []
         self._current_option = None
 
     @property
@@ -59,6 +60,7 @@ class SolisSelectEntity(RestoreEntity, SelectEntity):
             if e["name"] == option:
                 if on_value is not None:
                     await self._modbus_controller.async_write_holding_register(self._register, on_value)
+                    await self._write_companions()
                     self._attr_current_option = option
                     self.async_write_ha_state()
                     break
@@ -69,6 +71,24 @@ class SolisSelectEntity(RestoreEntity, SelectEntity):
     def device_info(self):
         """Return device info."""
         return self._modbus_controller.device_info
+
+    async def _write_companions(self) -> None:
+        """Re-write companion registers from cache after the primary write.
+
+        Some Solis firmware revisions require certain registers to be written in a
+        specific order for the values to latch (e.g. RC Timeout only takes effect if
+        Forced Charge/Discharge has been enabled first). Re-writing companion
+        registers here forms the second half of that combo.
+        """
+        for companion_register in self._companion_writes:
+            cached = cache_get(self._hass, self._modbus_controller, companion_register)
+            if cached is None:
+                _LOGGER.debug(
+                    "Skipping companion write for register %s: no cached value yet",
+                    companion_register,
+                )
+                continue
+            await self._modbus_controller.async_write_holding_register(companion_register, cached)
 
     def set_register_bit(self, on_value, bit_position, conflicts_with, requires):
         """Set or clear a specific bit in the Modbus register."""

--- a/tests/test_solis_select_entity.py
+++ b/tests/test_solis_select_entity.py
@@ -97,3 +97,121 @@ async def test_set_register_bit_with_requires(mock_hass, mock_controller):
         task = mock_hass.create_task.call_args[0][0]
         await task
         mock_controller.async_write_holding_register.assert_awaited_once_with(register, expected)
+
+
+@pytest.mark.asyncio
+async def test_companion_writes_after_on_value_select(mock_hass, mock_controller):
+    """After writing the primary register, companion registers must be re-written from cache, in order.
+
+    Solis firmware requires Forced Charge/Discharge (43135) to be enabled BEFORE the
+    related setpoints (43129, 43136) and RC Timeout (43282) are written for the values
+    to latch (issue #352).
+    """
+    primary_register = 43135
+    cached = {
+        43136: 1500,
+        43129: 1200,
+        43282: 30,
+    }
+
+    def fake_cache_get(_hass, _controller, register):
+        return cached.get(register)
+
+    with patch(
+        "custom_components.solis_modbus.sensors.solis_select_entity.cache_get",
+        side_effect=fake_cache_get,
+    ):
+        entity = SolisSelectEntity(
+            mock_hass,
+            mock_controller,
+            {
+                "register": primary_register,
+                "name": "RC Force Charge/Discharge",
+                "companion_writes": [43136, 43129, 43282],
+                "entities": [
+                    {"name": "None", "on_value": 0},
+                    {"name": "Solis RC Force Battery Charge", "on_value": 1},
+                ],
+            },
+        )
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_select_option("Solis RC Force Battery Charge")
+
+        assert mock_controller.async_write_holding_register.await_args_list == [
+            ((primary_register, 1), {}),
+            ((43136, cached[43136]), {}),
+            ((43129, cached[43129]), {}),
+            ((43282, cached[43282]), {}),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_companion_writes_skip_individual_uncached_registers(mock_hass, mock_controller):
+    """Companion writes only fire for registers that already have a cached value."""
+    primary_register = 43135
+    cached = {
+        43136: 1500,
+        # 43129 not yet polled
+        43282: 30,
+    }
+
+    def fake_cache_get(_hass, _controller, register):
+        return cached.get(register)
+
+    with patch(
+        "custom_components.solis_modbus.sensors.solis_select_entity.cache_get",
+        side_effect=fake_cache_get,
+    ):
+        entity = SolisSelectEntity(
+            mock_hass,
+            mock_controller,
+            {
+                "register": primary_register,
+                "name": "RC Force Charge/Discharge",
+                "companion_writes": [43136, 43129, 43282],
+                "entities": [
+                    {"name": "None", "on_value": 0},
+                    {"name": "Solis RC Force Battery Charge", "on_value": 1},
+                ],
+            },
+        )
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_select_option("Solis RC Force Battery Charge")
+
+        assert mock_controller.async_write_holding_register.await_args_list == [
+            ((primary_register, 1), {}),
+            ((43136, cached[43136]), {}),
+            ((43282, cached[43282]), {}),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_companion_writes_skipped_when_cache_empty(mock_hass, mock_controller):
+    """Companion writes should be skipped if the cached value isn't available yet."""
+    primary_register = 43135
+    companion_register = 43282
+
+    with patch(
+        "custom_components.solis_modbus.sensors.solis_select_entity.cache_get",
+        return_value=None,
+    ):
+        entity = SolisSelectEntity(
+            mock_hass,
+            mock_controller,
+            {
+                "register": primary_register,
+                "name": "RC Force Charge/Discharge",
+                "companion_writes": [companion_register],
+                "entities": [
+                    {"name": "None", "on_value": 0},
+                    {"name": "Solis RC Force Battery Charge", "on_value": 1},
+                ],
+            },
+        )
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_select_option("Solis RC Force Battery Charge")
+
+        mock_controller.async_write_holding_register.assert_awaited_once_with(primary_register, 1)


### PR DESCRIPTION
### **User description**
- Implement `companion_writes` to handle firmware requirements for sequential register writes.
- Add `_write_companions` method to re-write cached values for dependent registers after primary writes.
- Update tests to cover companion register behavior under various caching scenarios.
- Document firmware-specific behavior for issue #352.

## 🔄 Related Issues
Closes #352

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix RC timeout write ordering

- Re-write companion registers from cache

- Apply combo writes to RC select

- Add tests for cached write cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  select["RC force mode selected"]
  primary["Write register 43135"]
  cached["Read cached companion values"]
  companions["Rewrite 43136, 43129, 43282"]
  latched["RC settings latch correctly"]
  select -- "triggers" --> primary
  primary -- "then" --> cached
  cached -- "available values" --> companions
  companions -- "ensures" --> latched
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>select_sensors.py</strong><dd><code>Configure RC select companion register rewrites</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/select_sensors.py

<ul><li>Add <code>companion_writes</code> to <code>RC Force Charge/Discharge</code><br> <li> Document firmware-required write order for value latching<br> <li> Reapply cached charge, discharge, and timeout registers</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/377/files#diff-6c85f40d387b9df6d1ef801c31402274449e573fe55623fa56f4bde6be993d96">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>solis_select_entity.py</strong><dd><code>Rewrite cached companion registers after select</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_select_entity.py

<ul><li>Store optional <code>companion_writes</code> from entity definitions<br> <li> Trigger companion rewrites after primary <code>on_value</code> writes<br> <li> Add <code>_write_companions</code> helper using cached values<br> <li> Skip missing cached companions with debug logging</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/377/files#diff-5148bff83209796b04c787f8218342b1776f9de43adf16aebaa99808bdfe6edc">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_solis_select_entity.py</strong><dd><code>Cover companion write cache scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_solis_select_entity.py

<ul><li>Add test for ordered companion writes<br> <li> Verify partially uncached companions are skipped<br> <li> Verify empty cache skips all companion writes</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/377/files#diff-f6964af99f8a62e994ebdbb261107cb440d9d24c96be602ced220c4455cd7f56">+118/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

