### PR TITLE
Fix Home Assistant 2026.5 API removals

### DIFF
--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryError
+from homeassistant.components.persistent_notification import async_create as pn_create
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import (
@@ -121,7 +122,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # --- MISSING VALIDATION BLOCK RESTORED ---
     if not inverter_serial:
-        hass.components.persistent_notification.async_create(
+        pn_create(
+            hass,
             "Solis Modbus: Inverter Serial is missing. Please reconfigure the integration.",
             title="Solis Modbus Configuration Issue",
             notification_id="solis_modbus_missing_serial",
@@ -183,7 +185,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # defaulting
     if inverter_template is None:
-        hass.components.persistent_notification.async_create(
+        pn_create(
+            hass,
             "Your Solis Modbus configuration is invalid. Please reconfigure the integration.",
             title="Solis Modbus Configuration Issue",
             notification_id="solis_modbus_invalid_config",

--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -5,11 +5,11 @@ import logging
 from datetime import datetime
 
 import voluptuous as vol
+from homeassistant.components.persistent_notification import async_create as pn_create
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryError
-from homeassistant.components.persistent_notification import async_create as pn_create
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import (

--- a/custom_components/solis_modbus/config_flow.py
+++ b/custom_components/solis_modbus/config_flow.py
@@ -4,7 +4,7 @@ import re
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.config_entries import OptionsFlowWithConfigEntry
+from homeassistant.config_entries import OptionsFlow
 
 from . import ModbusController
 from .const import (
@@ -314,10 +314,10 @@ class ModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @config_entries.HANDLERS.register(DOMAIN)
     def async_get_options_flow(config_entry):
         """Return the options flow handler."""
-        return ModbusOptionsFlowHandler(config_entry)
+        return ModbusOptionsFlowHandler()
 
 
-class ModbusOptionsFlowHandler(OptionsFlowWithConfigEntry):
+class ModbusOptionsFlowHandler(OptionsFlow):
     """Handle options flow for Modbus."""
 
     async def async_step_init(self, user_input=None):

--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -3,7 +3,6 @@ import logging
 from datetime import UTC, datetime
 
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.template import is_number
 from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
 
 from custom_components.solis_modbus.client_manager import ModbusClientManager
@@ -23,6 +22,17 @@ from custom_components.solis_modbus.sensors.solis_base_sensor import SolisSensor
 from custom_components.solis_modbus.sensors.solis_derived_sensor import SolisDerivedSensor
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def is_number(value) -> bool:
+    """Check if a value is a finite number (replaces removed homeassistant.helpers.template.is_number)."""
+    if isinstance(value, bool):
+        return False
+    try:
+        number = float(value)
+    except (ValueError, TypeError):
+        return False
+    return number == number and number not in (float("inf"), float("-inf"))
 
 # Modbus exception codes we treat as address/map issues worth splitting reads (see data_retrieval recovery).
 RECOVERABLE_REGISTER_READ_EXCEPTIONS = frozenset({2, 3})

--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -34,6 +34,7 @@ def is_number(value) -> bool:
         return False
     return number == number and number not in (float("inf"), float("-inf"))
 
+
 # Modbus exception codes we treat as address/map issues worth splitting reads (see data_retrieval recovery).
 RECOVERABLE_REGISTER_READ_EXCEPTIONS = frozenset({2, 3})
 

--- a/custom_components/solis_modbus/sensors/solis_number_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_number_sensor.py
@@ -3,13 +3,23 @@ import logging
 from homeassistant.components.number import NumberEntity, NumberMode, RestoreNumber
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.template import is_number
 
 from custom_components.solis_modbus.const import CONTROLLER, REGISTER, SLAVE, VALUE
 from custom_components.solis_modbus.helpers import cache_get, is_correct_controller, register_update_signal
 from custom_components.solis_modbus.sensors.solis_base_sensor import SolisBaseSensor
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def is_number(value) -> bool:
+    """Check if a value is a finite number (replaces removed homeassistant.helpers.template.is_number)."""
+    if isinstance(value, bool):
+        return False
+    try:
+        number = float(value)
+    except (ValueError, TypeError):
+        return False
+    return number == number and number not in (float("inf"), float("-inf"))
 
 
 class SolisNumberEntity(RestoreNumber, NumberEntity):


### PR DESCRIPTION
### **User description**
## Summary

Fixes integration load failure introduced by Home Assistant 2026.5 (Python 3.14) which removed several deprecated APIs.

Closes #386

## Breaking Changes Fixed

### 1. `is_number` removed from `homeassistant.helpers.template`
- **Files**: `modbus_controller.py`, `sensors/solis_number_sensor.py`
- **Fix**: Replaced import with a local `is_number()` helper function using `float()` conversion
- This was the **primary blocker** — caused an `ImportError` that prevented the entire integration from loading

### 2. `OptionsFlowWithConfigEntry` removed from `homeassistant.config_entries`
- **File**: `config_flow.py`
- **Fix**: Changed base class to `OptionsFlow` and removed the `config_entry` constructor argument from `async_get_options_flow`
- Deprecated since HA 2024.7, now fully removed

### 3. `hass.components.persistent_notification` removed
- **File**: `__init__.py`
- **Fix**: Import `async_create` directly from `homeassistant.components.persistent_notification` and call it with `hass` as first argument
- The `hass.components` attribute no longer exists in HA 2026.5

## Test Environment
- Home Assistant 2026.5.0
- Python 3.14
- Solis S5-EH1P inverter via TCP (Modbus)
- Integration confirmed loading successfully after these fixes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Restore HA 2026.5 compatibility

- Replace removed `is_number` imports

- Migrate options flow API

- Fix persistent notification calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ha["HA 2026.5 removed APIs"]
  num["Local is_number helpers"]
  flow["OptionsFlow-based options handler"]
  notif["Direct pn_create notification calls"]
  ha -- "template helper removed" --> num
  ha -- "config flow class removed" --> flow
  ha -- "component access removed" --> notif
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Fix persistent notification API usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/__init__.py

<ul><li>Import <code>async_create</code> as <code>pn_create</code><br> <li> Replace <code>hass.components</code> notification usage<br> <li> Pass <code>hass</code> directly into notifications</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/387/files#diff-90c384b3c13c51777899c6bb6f69f01762e31d9fed1da9933a765b6e6fe60be3">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config_flow.py</strong><dd><code>Migrate config flow to new API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/config_flow.py

<ul><li>Replace <code>OptionsFlowWithConfigEntry</code> with <code>OptionsFlow</code><br> <li> Return <code>ModbusOptionsFlowHandler()</code> without arguments<br> <li> Update options flow to use current HA API</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/387/files#diff-2e983e3a2a647135a82c37e4ee143bab14008b7fa1c13da9da8dea903c2e14c3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>modbus_controller.py</strong><dd><code>Add local numeric validation helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/modbus_controller.py

<ul><li>Remove dependency on HA <code>is_number</code><br> <li> Add local numeric validation helper<br> <li> Handle <code>ValueError</code> and <code>TypeError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/387/files#diff-e230937b651240e2eb7a7c8fd2f5c2db9521105ae3be0352f3439850b9089f1e">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>solis_number_sensor.py</strong><dd><code>Replace removed template number helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_number_sensor.py

<ul><li>Remove HA template <code>is_number</code> import<br> <li> Add local <code>float()</code>-based number checker<br> <li> Preserve numeric validation behavior locally</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/387/files#diff-12de5d2a79db4982e540517bacb61591ae1560a31897d2b123b51a5be1cd2b24">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

