### PR TITLE
Reset stale Modbus connections after read/write failures

### DIFF
--- a/custom_components/solis_modbus/client_manager.py
+++ b/custom_components/solis_modbus/client_manager.py
@@ -114,7 +114,7 @@ class ModbusClientManager:
                 _LOGGER.debug(f"Closing and removing Modbus client for {connection_id}")
                 client = self._clients[connection_id]["client"]
                 try:
-                    if hasattr(client, 'connected') and client.connected:
+                    if hasattr(client, "connected") and client.connected:
                         client.close()
                 except Exception as e:
                     _LOGGER.debug(f"Error closing client for {connection_id}: {e}")

--- a/custom_components/solis_modbus/client_manager.py
+++ b/custom_components/solis_modbus/client_manager.py
@@ -113,6 +113,9 @@ class ModbusClientManager:
             if self._clients[connection_id]["ref_count"] <= 0:
                 _LOGGER.debug(f"Closing and removing Modbus client for {connection_id}")
                 client = self._clients[connection_id]["client"]
-                if client.connected:
-                    client.close()
+                try:
+                    if hasattr(client, 'connected') and client.connected:
+                        client.close()
+                except Exception as e:
+                    _LOGGER.debug(f"Error closing client for {connection_id}: {e}")
                 del self._clients[connection_id]

--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -217,25 +217,35 @@ class ModbusController:
             async with self.poll_lock:
                 await self.inter_frame_wait(is_write=True)  # Delay before write
 
-                # Different pymodbus APIs for TCP vs Serial
-                if self.connection_type == CONN_TYPE_TCP:
-                    result = await self.client.write_registers(address=start_register, values=values, device_id=self.device_id)
-                else:
-                    self.client.slave = self.device_id
-                    result = await self.client.write_registers(address=start_register, values=values)
-                _LOGGER.debug(
-                    f"({self.host}.{self.device_id}) Write Holding Register block for {len(values)} registers starting at register = {start_register}"
-                )
+                try:
+                    # Different pymodbus APIs for TCP vs Serial
+                    if self.connection_type == CONN_TYPE_TCP:
+                        result = await self.client.write_registers(address=start_register, values=values, device_id=self.device_id)
+                    else:
+                        self.client.slave = self.device_id
+                        result = await self.client.write_registers(address=start_register, values=values)
+                    _LOGGER.debug(
+                        f"({self.host}.{self.device_id}) Write Holding Register block for {len(values)} registers starting at register = {start_register}"
+                    )
 
-                if result.isError():
-                    _LOGGER.error(f"({self.host}.{self.device_id}) Write block failed: {result}")
+                    if result.isError():
+                        _LOGGER.error(f"({self.host}.{self.device_id}) Write block failed: {result}")
+                        return None
+
+                    for i, value in enumerate(values):
+                        reg_addr = start_register + i
+                        cache_save(self.hass, self, reg_addr, value)
+                        notify_register_update(self.hass, self, reg_addr, value)
+                    return result
+                except Exception as write_error:
+                    _LOGGER.error(f"({self.host}.{self.device_id}) Exception during write holding registers {start_register}-{start_register + len(values) - 1}: {str(write_error)}")
+                    # Close connection to clear any stale state/responses
+                    try:
+                        if hasattr(self.client, 'connected') and self.client.connected:
+                            self.client.close()
+                    except Exception:
+                        pass
                     return None
-
-                for i, value in enumerate(values):
-                    reg_addr = start_register + i
-                    cache_save(self.hass, self, reg_addr, value)
-                    notify_register_update(self.hass, self, reg_addr, value)
-                return result
         except Exception as e:
             _LOGGER.error(f"({self.host}.{self.device_id}) Failed to write holding registers {start_register}-{start_register + len(values) - 1}: {str(e)}")
             return None
@@ -273,22 +283,35 @@ class ModbusController:
         async with self.poll_lock:
             await self.inter_frame_wait()
 
-            if self.connection_type == CONN_TYPE_TCP:
-                result = await self.client.read_input_registers(address=register, count=count, device_id=self.device_id)
-            else:
-                self.client.slave = self.device_id
-                result = await self.client.read_input_registers(address=register, count=count)
+            try:
+                if self.connection_type == CONN_TYPE_TCP:
+                    result = await self.client.read_input_registers(address=register, count=count, device_id=self.device_id)
+                else:
+                    self.client.slave = self.device_id
+                    result = await self.client.read_input_registers(address=register, count=count)
 
-            _LOGGER.debug(f"({self.host}.{self.device_id}) Read Input Registers: register = {register}, count = {count}")
+                _LOGGER.debug(f"({self.host}.{self.device_id}) Read Input Registers: register = {register}, count = {count}")
 
-            if result.isError():
-                exc = _exception_code_from_modbus_result(result)
+                if result.isError():
+                    exc = _exception_code_from_modbus_result(result)
+                    log_fn = _LOGGER.debug if quiet else _LOGGER.error
+                    log_fn(f"({self.host}.{self.device_id}) Failed to read input registers starting at {register}: {result}")
+                    return None, exc
+
+                self._last_modbus_success = datetime.now(UTC)
+                return result.registers, None
+            except Exception as e:
+                # Log the exception, close connection, and return error
+                error_msg = str(e)
                 log_fn = _LOGGER.debug if quiet else _LOGGER.error
-                log_fn(f"({self.host}.{self.device_id}) Failed to read input registers starting at {register}: {result}")
-                return None, exc
-
-            self._last_modbus_success = datetime.now(UTC)
-            return result.registers, None
+                log_fn(f"({self.host}.{self.device_id}) Exception reading input registers at {register}: {error_msg}")
+                # Close connection to clear any stale state/responses
+                try:
+                    if hasattr(self.client, 'connected') and self.client.connected:
+                        self.client.close()
+                except Exception:
+                    pass
+                return None, None
 
     async def _async_read_input_register_raw(self, register, count):
         """Raw read input registers without connection check (internal use)."""
@@ -329,22 +352,35 @@ class ModbusController:
         async with self.poll_lock:
             await self.inter_frame_wait()
 
-            if self.connection_type == CONN_TYPE_TCP:
-                result = await self.client.read_holding_registers(address=register, count=count, device_id=self.device_id)
-            else:
-                self.client.slave = self.device_id
-                result = await self.client.read_holding_registers(address=register, count=count)
+            try:
+                if self.connection_type == CONN_TYPE_TCP:
+                    result = await self.client.read_holding_registers(address=register, count=count, device_id=self.device_id)
+                else:
+                    self.client.slave = self.device_id
+                    result = await self.client.read_holding_registers(address=register, count=count)
 
-            _LOGGER.debug(f"({self.host}.{self.device_id}) Read Holding Registers: register = {register}, count = {count}")
+                _LOGGER.debug(f"({self.host}.{self.device_id}) Read Holding Registers: register = {register}, count = {count}")
 
-            if result.isError():
-                exc = _exception_code_from_modbus_result(result)
+                if result.isError():
+                    exc = _exception_code_from_modbus_result(result)
+                    log_fn = _LOGGER.debug if quiet else _LOGGER.error
+                    log_fn(f"({self.host}.{self.device_id}) Failed to read holding registers starting at {register}: {result}")
+                    return None, exc
+
+                self._last_modbus_success = datetime.now(UTC)
+                return result.registers, None
+            except Exception as e:
+                # Log the exception, close connection, and return error
+                error_msg = str(e)
                 log_fn = _LOGGER.debug if quiet else _LOGGER.error
-                log_fn(f"({self.host}.{self.device_id}) Failed to read holding registers starting at {register}: {result}")
-                return None, exc
-
-            self._last_modbus_success = datetime.now(UTC)
-            return result.registers, None
+                log_fn(f"({self.host}.{self.device_id}) Exception reading holding registers at {register}: {error_msg}")
+                # Close connection to clear any stale state/responses
+                try:
+                    if hasattr(self.client, 'connected') and self.client.connected:
+                        self.client.close()
+                except Exception:
+                    pass
+                return None, None
 
     async def _async_read_holding_register_raw(self, register, count):
         registers, _err = await self._async_read_holding_register_raw_detailed(register, count, quiet=False)
@@ -406,10 +442,22 @@ class ModbusController:
                     return True
                 self.connect_failures += 1
                 _LOGGER.debug(f"⚠️ ({self.host}:{self.port}.{self.device_id}) Connection attempt {self.connect_failures} failed")
+                # Close connection to clear any pending responses/state
+                try:
+                    if hasattr(self.client, 'connected') and self.client.connected:
+                        self.client.close()
+                except Exception:
+                    pass
                 return False
             except Exception as e:
                 self.connect_failures += 1
                 _LOGGER.debug(f"❌ ({self.host}.{self.device_id}) Connection error (attempt {self.connect_failures}): {e}")
+                # Close connection to clear any pending responses/state on connection error
+                try:
+                    if hasattr(self.client, 'connected') and self.client.connected:
+                        self.client.close()
+                except Exception:
+                    pass
                 return False
 
         lock = self.poll_lock

--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -249,7 +249,8 @@ class ModbusController:
                         notify_register_update(self.hass, self, reg_addr, value)
                     return result
                 except Exception as write_error:
-                    _LOGGER.error(f"({self.host}.{self.device_id}) Exception during write holding registers {start_register}-{start_register + len(values) - 1}: {str(write_error)}")
+                    _LOGGER.error(f"({self.host}.{self.device_id}) Exception during write holding registers "
+                                  f"{start_register}-{start_register + len(values) - 1}: {str(write_error)}")
                     # Close connection to clear any stale state/responses
                     try:
                         if hasattr(self.client, 'connected') and self.client.connected:

--- a/custom_components/solis_modbus/modbus_controller.py
+++ b/custom_components/solis_modbus/modbus_controller.py
@@ -249,11 +249,13 @@ class ModbusController:
                         notify_register_update(self.hass, self, reg_addr, value)
                     return result
                 except Exception as write_error:
-                    _LOGGER.error(f"({self.host}.{self.device_id}) Exception during write holding registers "
-                                  f"{start_register}-{start_register + len(values) - 1}: {str(write_error)}")
+                    _LOGGER.error(
+                        f"({self.host}.{self.device_id}) Exception during write holding registers "
+                        f"{start_register}-{start_register + len(values) - 1}: {str(write_error)}"
+                    )
                     # Close connection to clear any stale state/responses
                     try:
-                        if hasattr(self.client, 'connected') and self.client.connected:
+                        if hasattr(self.client, "connected") and self.client.connected:
                             self.client.close()
                     except Exception:
                         pass
@@ -319,7 +321,7 @@ class ModbusController:
                 log_fn(f"({self.host}.{self.device_id}) Exception reading input registers at {register}: {error_msg}")
                 # Close connection to clear any stale state/responses
                 try:
-                    if hasattr(self.client, 'connected') and self.client.connected:
+                    if hasattr(self.client, "connected") and self.client.connected:
                         self.client.close()
                 except Exception:
                     pass
@@ -388,7 +390,7 @@ class ModbusController:
                 log_fn(f"({self.host}.{self.device_id}) Exception reading holding registers at {register}: {error_msg}")
                 # Close connection to clear any stale state/responses
                 try:
-                    if hasattr(self.client, 'connected') and self.client.connected:
+                    if hasattr(self.client, "connected") and self.client.connected:
                         self.client.close()
                 except Exception:
                     pass
@@ -456,7 +458,7 @@ class ModbusController:
                 _LOGGER.debug(f"⚠️ ({self.host}:{self.port}.{self.device_id}) Connection attempt {self.connect_failures} failed")
                 # Close connection to clear any pending responses/state
                 try:
-                    if hasattr(self.client, 'connected') and self.client.connected:
+                    if hasattr(self.client, "connected") and self.client.connected:
                         self.client.close()
                 except Exception:
                     pass
@@ -466,7 +468,7 @@ class ModbusController:
                 _LOGGER.debug(f"❌ ({self.host}.{self.device_id}) Connection error (attempt {self.connect_failures}): {e}")
                 # Close connection to clear any pending responses/state on connection error
                 try:
-                    if hasattr(self.client, 'connected') and self.client.connected:
+                    if hasattr(self.client, "connected") and self.client.connected:
                         self.client.close()
                 except Exception:
                     pass


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #388 (potentially)

## ✅ Testing Steps
Solis S6 inverter, but the issue is intermittent anyway

## ➕ Additional Notes
Mostly just defensive exception handling


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Safely handle Modbus client close failures

- Reset stale connections after read errors

- Reset stale connections after write errors

- Clear client state after failed connects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Modbus read/write/connect error"]
  B["Safely close current client"]
  C["Clear stale socket or response state"]
  D["Allow next operation to reconnect"]
  A -- "triggers" --> B
  B -- "resets" --> C
  C -- "enables" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client_manager.py</strong><dd><code>Guard client cleanup against close exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/client_manager.py

<ul><li>Wrap client shutdown in <code>try/except</code><br> <li> Check <code>connected</code> defensively with <code>hasattr</code><br> <li> Log debug details when close fails</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/389/files#diff-0d0cc9dc21fb88eb9686bc313538e7ae7444dcb613992cff1d5e1af2c5289ab0">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modbus_controller.py</strong><dd><code>Reset stale clients after Modbus operation failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/modbus_controller.py

<ul><li>Wrap Modbus write calls in exception handling<br> <li> Close connected clients after read exceptions<br> <li> Close connected clients after write exceptions<br> <li> Reset client state after failed connects</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/389/files#diff-e230937b651240e2eb7a7c8fd2f5c2db9521105ae3be0352f3439850b9089f1e">+92/-44</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

