### PR TITLE
Fix net grid energy state class

### DIFF
--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -3568,7 +3568,7 @@ hybrid_sensors_derived = [
         "device_class": SensorDeviceClass.ENERGY,
         "multiplier": 0.1,
         "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "register": ["33175", "33171"],
     },
     {


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Fixes #398

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects net energy state class

- Allows signed daily grid energy

- Prevents invalid recorder statistics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Today Net Grid Energy"] -- "can be negative" --> B["SensorStateClass.TOTAL"]
  B -- "valid signed totals" --> C["Cleaner recorder statistics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid_sensors.py</strong><dd><code>Correct net grid energy classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/hybrid_sensors.py

<ul><li>Changes <code>Today Net Grid Energy</code> from <code>TOTAL_INCREASING</code> to <code>TOTAL</code>.<br> <li> Aligns the sensor state class with signed net energy values.<br> <li> Prevents negative values from violating Home Assistant statistics <br>rules.</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/399/files#diff-540e84e48ae8dd4a164fe7fa970bf88a7375c29588090e2cfe4b8bf7ff16518f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Today Net Grid Energy" sensor metric classification for improved accuracy in tracking and system calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pho3niX90/solis_modbus/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->