### PR TITLE
Fix Modbus reconnect watchdog and clean reloads

### DIFF
--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -431,8 +431,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a Modbus config entry."""
     _LOGGER.debug("init async_unload_entry")
 
-    # Unload platforms associated with this integration
-    unload_ok = all(await asyncio.gather(*(hass.config_entries.async_forward_entry_unload(entry, platform) for platform in PLATFORMS)))
+    # Unload platforms associated with this integration. SENSOR is forwarded
+    # in async_setup_entry alongside PLATFORMS, so it must be unloaded here too —
+    # otherwise a reload leaves the sensor platform set up and the next setup
+    # fails with "config entry for solis_modbus.sensor has already been setup!".
+    unload_ok = all(
+        await asyncio.gather(
+            *(
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in [Platform.SENSOR, *PLATFORMS]
+            )
+        )
+    )
 
     # Clean up resources
     if unload_ok:

--- a/custom_components/solis_modbus/data_retrieval.py
+++ b/custom_components/solis_modbus/data_retrieval.py
@@ -191,31 +191,35 @@ class DataRetrieval:
         if self.connection_check:
             return
 
+        # Re-entrancy guard: must be released on every exit path, otherwise the
+        # periodic watchdog (and startup poll) silently stops reconnecting after
+        # the first "already connected" tick — leaving the integration offline
+        # until a manual reload. Use try/finally so it is always reset.
         self.connection_check = True
+        try:
+            # Emit controller status (dispatcher — not persisted to recorder)
+            notify_register_update(self.hass, self.controller, 90005, self.controller.enabled)
 
-        # Emit controller status (dispatcher — not persisted to recorder)
-        notify_register_update(self.hass, self.controller, 90005, self.controller.enabled)
+            if self.controller.connected():
+                if self.first_poll:
+                    await self.modbus_update_all()
+                    self.first_poll = False
+                return
 
-        if self.controller.connected():
-            if self.first_poll:
-                await self.modbus_update_all()
-                self.first_poll = False
-            return
+            retry_delay = 0.5
+            while not self.controller.connected():
+                try:
+                    if await self.controller.connect():
+                        _LOGGER.info(f"✅({self.controller.host}.{self.controller.slave}) Modbus controller connected successfully.")
+                        break
+                    _LOGGER.debug(f"⚠️({self.controller.host}.{self.controller.slave}) Modbus connection failed, retrying in {retry_delay:.2f} seconds...")
+                except Exception as e:
+                    _LOGGER.error(f"❌({self.controller.host}.{self.controller.slave}) Connection error : {e}")
 
-        retry_delay = 0.5
-        while not self.controller.connected():
-            try:
-                if await self.controller.connect():
-                    _LOGGER.info(f"✅({self.controller.host}.{self.controller.slave}) Modbus controller connected successfully.")
-                    break
-                _LOGGER.debug(f"⚠️({self.controller.host}.{self.controller.slave}) Modbus connection failed, retrying in {retry_delay:.2f} seconds...")
-            except Exception as e:
-                _LOGGER.error(f"❌({self.controller.host}.{self.controller.slave}) Connection error : {e}")
-
-            await asyncio.sleep(retry_delay)
-            retry_delay = min(retry_delay * 2, 30)
-
-        self.connection_check = False
+                await asyncio.sleep(retry_delay)
+                retry_delay = min(retry_delay * 2, 30)
+        finally:
+            self.connection_check = False
 
     async def poll_controller(self, event=None):
         """Poll the Modbus controller for data, retrying until success.


### PR DESCRIPTION
### **User description**
## Problem

On a TCP coordinator (e.g. a Solis **S2-WL-ST** WiFi logging stick) the Modbus connection occasionally drops. When it does, the integration **never reconnects on its own** — every entity goes unavailable/stale until the user manually reloads the integration or restarts Home Assistant. Reloading as a workaround also logs a setup error.

Two small, related fixes.

## 1. Reconnect watchdog never re-arms (`data_retrieval.py`)

`check_connection()` uses `self.connection_check` as a re-entrancy guard, but the "already connected" branch `return`s without resetting it:

```python
self.connection_check = True
...
if self.controller.connected():
    ...
    return                      # <-- guard left True
...
self.connection_check = False   # only reached via the reconnect loop
```

After the first 2-minute tick where the controller is connected, the guard is stuck `True`, so every later `check_connection()` hits `if self.connection_check: return` and no-ops. Because `get_modbus_updates()` also returns early while disconnected (never reaching the read path that reconnects), a single dropped socket leaves the integration offline indefinitely.

**Fix:** wrap the body in `try/finally` so the guard is always released.

## 2. SENSOR platform not unloaded (`__init__.py`)

`async_setup_entry` forwards `[Platform.SENSOR]` **and** `PLATFORMS`, but `async_unload_entry` only unloads `PLATFORMS`. `SENSOR` is never torn down, so a reload fails on the next setup with `config entry for solis_modbus.sensor has already been setup!`. This matters because reloading is the natural recovery action.

**Fix:** unload `[Platform.SENSOR, *PLATFORMS]`.

## Testing

Reproduced on a live **S6-EH1P** via an S2-WL-ST (`tcp://…:8899`): the integration had been offline ~10 h after an overnight drop despite the stick being reachable the whole time. With these patches applied:

- Reloading the entry is clean — no more `already been setup!` error, reconnects fine.
- The periodic watchdog releases its guard, so it reconnects after a drop instead of staying down.

## Out of scope (possible follow-ups)

- Connection drop/reconnect events are logged at `DEBUG`, so they're invisible at the default log level — bumping *lost → WARNING* / *recovered → INFO* would aid diagnosis.
- Recovery currently waits up to the 2-minute watchdog interval; reconnecting directly from the poll path would be faster (but more aggressive toward flaky sticks, so left as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Re-arm Modbus reconnect watchdog

- Unload sensor platform on reload

- Prevent stale offline integration state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  drop["Dropped Modbus connection"]
  watchdog["Reconnect watchdog"]
  guard["Guard released with finally"]
  reconnect["Connection recovers"]
  reload["Config entry reload"]
  unload["Unload sensor and platforms"]
  clean["Clean setup"]

  drop -- "detected by" --> watchdog
  watchdog -- "resets" --> guard
  guard -- "allows retries" --> reconnect
  reload -- "runs" --> unload
  unload -- "prevents duplicate setup" --> clean
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Unload sensor platform during entry cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/__init__.py

<ul><li>Adds <code>Platform.SENSOR</code> to unload targets.<br> <li> Keeps setup and unload platform handling symmetric.<br> <li> Prevents reload failures from lingering sensor setup.</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/405/files#diff-90c384b3c13c51777899c6bb6f69f01762e31d9fed1da9933a765b6e6fe60be3">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data_retrieval.py</strong><dd><code>Always release Modbus reconnect guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/data_retrieval.py

<ul><li>Wraps <code>connection_check</code> guarded logic in <code>try/finally</code>.<br> <li> Ensures reconnect guard resets on every exit path.<br> <li> Preserves existing reconnect retry and first-poll behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/405/files#diff-80ac627de8506ebe8f2aca62b1581ad9f9a89d3002dacae88dc14fbc31218927">+28/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected incomplete unloading of sensor functionality during system reloads, preventing residual platform states
  * Enhanced connection monitoring to prevent watchdog logic from becoming unresponsive after successful connections are established

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pho3niX90/solis_modbus/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->