### PR TITLE
Preserve declared export limits and support S6-EH3P20K

### DIFF
--- a/custom_components/solis_modbus/data/solis_config.py
+++ b/custom_components/solis_modbus/data/solis_config.py
@@ -119,7 +119,7 @@ SOLIS_INVERTERS = [
     ),
     InverterConfig(
         model="S6-EH3P",
-        wattage=[8000, 10000, 12000, 15000, 29900, 30000, 40000, 49000, 50000, 60000],
+        wattage=[8000, 10000, 12000, 15000, 20000, 29900, 30000, 40000, 49000, 50000, 60000],
         phases=3,
         type=InverterType.HYBRID,
         features=[InverterFeature.SMART_PORT],

--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -27,6 +27,10 @@ from custom_components.solis_modbus.helpers import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Fallback ceiling for editable entities whose definition declares no "max" and whose
+# unit gives us nothing to derive one from.
+DEFAULT_MAX_VALUE = 3000
+
 
 class SolisBaseSensor:
     """Base class for all Solis sensors."""
@@ -84,7 +88,6 @@ class SolisBaseSensor:
         self.unit_of_measurement = unit_of_measurement
         self.hidden = hidden
         self.state_class = state_class
-        self.max_value = max_value
         self.adjust_max(max_value)
         self.step = self.get_step(step)
         self.enabled = enabled
@@ -117,18 +120,31 @@ class SolisBaseSensor:
                 self.multiplier = 0.01
 
     def adjust_max(self, max_default):
+        """Derive a sensible max for entities whose definition didn't declare one.
+
+        A declared ``"max"`` always wins. Deriving it from the inverter rating is only
+        a fallback for definitions that omit it: several registers are *grid*
+        constraints rather than inverter-output constraints — the export limit at
+        43074/43291 being the obvious case — so clamping them to the inverter's rated
+        wattage caps users below what their grid connection allows (issue #438).
+        """
+        if max_default is not None:
+            self.max_value = max_default
+            return
+
         try:
-            new_max = max_default
+            new_max = DEFAULT_MAX_VALUE
             if self.unit_of_measurement == UnitOfElectricCurrent.AMPERE:
                 new_max = round((self.controller.inverter_config.wattage_chosen / 44) / 10) * 20
             elif self.unit_of_measurement == UnitOfPower.WATT:
                 new_max = self.controller.inverter_config.wattage_chosen
             elif self.unit_of_measurement == UnitOfPower.KILO_WATT:
                 new_max = self.controller.inverter_config.wattage_chosen / 1000
-            _LOGGER.debug(f"max value for {self.registrars} with UOM {self.unit_of_measurement} set to {new_max} instead of {max_default}")
+            _LOGGER.debug(f"max value for {self.registrars} with UOM {self.unit_of_measurement} derived as {new_max} (no max declared)")
             self.max_value = new_max
         except Exception as e:
             _LOGGER.error("❌ Dynamic UOM set failed, wanted = %s : %s", self.controller.inverter_config.wattage_chosen, e)
+            self.max_value = DEFAULT_MAX_VALUE
 
     def get_step(self, wanted_step):
         if wanted_step is not None:
@@ -243,7 +259,7 @@ class SolisSensorGroup:
                     unit_of_measurement=entity.get("unit_of_measurement", None),
                     hidden=entity.get("hidden", False),
                     editable=entity.get("editable", False),
-                    max_value=entity.get("max", 3000),
+                    max_value=entity.get("max", None),
                     min_value=entity.get("min", 0),
                     step=entity.get("step", None),
                     identification=identification,

--- a/tests/test_max_value_declaration.py
+++ b/tests/test_max_value_declaration.py
@@ -1,0 +1,155 @@
+"""A declared "max" in a sensor definition must survive.
+
+Regression cover for issue #438: the export power limit is a *grid-connection*
+constraint, not an inverter-output one, so deriving its ceiling from the inverter's
+rated wattage capped users below what their grid connection allows. An S6-EH3P20K-H
+owner picking the config-flow default model (S6-EH1P, max wattage 8000) got a
+0-8000 W export limit despite the definition declaring max 20000.
+"""
+
+import unittest
+
+from homeassistant.const import UnitOfElectricCurrent, UnitOfPower
+
+from custom_components.solis_modbus.data.solis_config import SOLIS_INVERTERS
+from custom_components.solis_modbus.sensors.solis_base_sensor import (
+    DEFAULT_MAX_VALUE,
+    SolisBaseSensor,
+    SolisSensorGroup,
+)
+
+
+class MockController:
+    def __init__(self, wattage_chosen=8000):
+        class MockConfig:
+            model = "TEST"
+            features = []
+
+        MockConfig.wattage_chosen = wattage_chosen
+        self.inverter_config = MockConfig()
+        self.device_serial_number = "SN438"
+        self.identification = None
+        self.host = "127.0.0.1"
+
+
+def _group(controller, entity):
+    return SolisSensorGroup(
+        hass=None,
+        definition={"register_start": int(entity["register"][0]), "entities": [entity]},
+        controller=controller,
+    )
+
+
+class TestDeclaredMaxSurvives(unittest.TestCase):
+    def setUp(self):
+        # 8000 is the S6-EH1P ceiling that produced the 0-8000 W in the report.
+        self.controller = MockController(wattage_chosen=8000)
+
+    def test_declared_max_survives_on_watt_entity(self):
+        """Backflow Power (43074) declares max 20000 — it must not be clamped to 8000."""
+        sensor = _group(
+            self.controller,
+            {
+                "name": "Backflow Power",
+                "register": ["43074"],
+                "unit_of_measurement": UnitOfPower.WATT,
+                "editable": True,
+                "multiplier": 100,
+                "min": 0,
+                "max": 20000,
+            },
+        ).sensors[0]
+        self.assertEqual(sensor.max_value, 20000)
+
+    def test_declared_max_survives_on_flexible_export(self):
+        """Flexible Export Backflow Power (43291) declares max 15000."""
+        sensor = _group(
+            self.controller,
+            {
+                "name": "Flexible Export Backflow Power",
+                "register": ["43291"],
+                "unit_of_measurement": UnitOfPower.WATT,
+                "editable": True,
+                "multiplier": 100,
+                "max": 15000,
+            },
+        ).sensors[0]
+        self.assertEqual(sensor.max_value, 15000)
+
+    def test_declared_max_survives_below_rating_too(self):
+        """The rule is 'declared wins', not 'take the larger of the two'."""
+        sensor = _group(
+            self.controller,
+            {
+                "name": "Export Calibration",
+                "register": ["43195"],
+                "unit_of_measurement": UnitOfPower.WATT,
+                "editable": True,
+                "max": 1000,
+            },
+        ).sensors[0]
+        self.assertEqual(sensor.max_value, 1000)
+
+
+class TestUndeclaredMaxStillDerived(unittest.TestCase):
+    """Definitions that omit "max" keep deriving one from the inverter rating."""
+
+    def setUp(self):
+        self.controller = MockController(wattage_chosen=8000)
+
+    def test_watt_entity_without_max_uses_wattage(self):
+        sensor = _group(
+            self.controller,
+            {"name": "Some Power", "register": ["43100"], "unit_of_measurement": UnitOfPower.WATT, "editable": True},
+        ).sensors[0]
+        self.assertEqual(sensor.max_value, 8000)
+
+    def test_kilowatt_entity_without_max_scales(self):
+        sensor = _group(
+            self.controller,
+            {"name": "Some Power kW", "register": ["43101"], "unit_of_measurement": UnitOfPower.KILO_WATT, "editable": True},
+        ).sensors[0]
+        self.assertEqual(sensor.max_value, 8)
+
+    def test_ampere_entity_without_max_derives_current(self):
+        sensor = _group(
+            self.controller,
+            {
+                "name": "Some Current",
+                "register": ["43102"],
+                "unit_of_measurement": UnitOfElectricCurrent.AMPERE,
+                "editable": True,
+            },
+        ).sensors[0]
+        self.assertEqual(sensor.max_value, round((8000 / 44) / 10) * 20)
+
+    def test_unitless_entity_without_max_falls_back_to_default(self):
+        sensor = _group(
+            self.controller,
+            {"name": "Some Setting", "register": ["43103"], "editable": True},
+        ).sensors[0]
+        self.assertEqual(sensor.max_value, DEFAULT_MAX_VALUE)
+
+    def test_direct_construction_without_max_is_unaffected(self):
+        sensor = SolisBaseSensor(
+            hass=None,
+            controller=self.controller,
+            unique_id="u",
+            name="n",
+            registrars=[43104],
+            write_register=None,
+            multiplier=1,
+            unit_of_measurement=UnitOfPower.WATT,
+        )
+        self.assertEqual(sensor.max_value, 8000)
+
+
+class TestInverterWattageCatalogue(unittest.TestCase):
+    def test_s6_eh3p_covers_the_20k_sku(self):
+        """S6-EH3P20K-H is a shipping SKU and was unrepresentable (issue #438)."""
+        s6_eh3p = next(i for i in SOLIS_INVERTERS if i.model == "S6-EH3P")
+        self.assertIn(20000, s6_eh3p.wattage)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
Fixes #438.

## The report

An S6-EH3P20K-H owner is allowed to export 15 kW, and SolisCloud lets him set it, but
the integration capped the export-limit number at **0–8000 W**.

## Root cause

`SolisBaseSensor.adjust_max()` replaced the max of *every* watt/kilowatt/ampere-unit
entity with `InverterConfig.wattage_chosen`, discarding whatever the sensor definition
declared:

```python
def adjust_max(self, max_default):
    new_max = max_default
    if self.unit_of_measurement == UnitOfElectricCurrent.AMPERE:
        ...
    elif self.unit_of_measurement == UnitOfPower.WATT:
        new_max = self.controller.inverter_config.wattage_chosen   # declared max discarded
```

So `Backflow Power` (43074, `"max": 20000`) and `Flexible Export Backflow Power`
(43291, `"max": 15000`) never used their declared ceilings.

`wattage_chosen` is `max(wattage)` for the selected model (`solis_config.py`) and is not
user-selectable — the config flow offers only a model dropdown. Its default is the first
entry, `S6-EH1P`, whose largest variant is **8000 W**, which reproduces the reported
range exactly. `8000` is unique to `S6-EH1P` across `SOLIS_INVERTERS`.

Beyond the specific range, deriving this particular ceiling from the inverter rating is
conceptually wrong: an export limit is a **grid-connection** constraint, not an
inverter-output one. The register itself is 16-bit at `multiplier: 100`, so the hardware
is not the limit either.

## The change

- `adjust_max()` only derives a ceiling when the definition **omitted** `"max"`. A
  declared value is now kept verbatim. Definitions that omit it behave exactly as before.
- `SolisSensorGroup` passes `entity.get("max", None)` so "declared" and "defaulted" are
  distinguishable; the old `3000` fallback becomes `DEFAULT_MAX_VALUE`.
- Added `20000` to the `S6-EH3P` wattage list — the S6-EH3P20K-H is a shipping SKU that
  was previously unrepresentable.

This also removes a footgun for contributors: an explicit `"max"` on a new watt-unit
register was silently ignored, which is surprising every time.

## Tests

9 added in `tests/test_max_value_declaration.py`:

- declared max survives on 43074 and 43291, and also when it is *below* the rating, so
  the rule is "declared wins" rather than "take the larger of the two"
- the derivation paths still work when `"max"` is omitted — W, kW, A and unitless
- `S6-EH3P` covers the 20 kW SKU

**220 pass**, `ruff check` and `ruff format --check` clean.

## Note for the reporter

@tonunapp-cell — worth confirming which model you picked in the integration setup. If it
was the default `S6-EH1P` rather than `S6-EH3P`, reconfiguring to the correct model is
also worth doing, since the model drives battery-current ranges too. The diagnostics
download exposes `wattage_chosen` if you want to check.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Preserve explicitly declared sensor maximum values

- Derive limits only when maximums are omitted

- Add S6-EH3P 20 kW support

- Cover export-limit regression and fallbacks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  definition["Sensor definition"] -- "declares max" --> declared["Preserve declared ceiling"]
  definition -- "omits max" --> derived["Derive ceiling from inverter rating"]
  derived -- "unit cannot derive" --> fallback["Use default ceiling"]
  catalogue["S6-EH3P catalogue"] -- "adds SKU" --> model["20 kW inverter support"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_config.py</strong><dd><code>Add S6-EH3P 20 kW model rating</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/data/solis_config.py

<ul><li>Adds <code>20000</code> to S6-EH3P wattage options<br> <li> Represents the S6-EH3P20K-H inverter SKU</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/441/files#diff-6509bce3369055e023cdbbb3b1c325fee652d5f9e40e2d74a7d7ad8ff3a9b8c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_base_sensor.py</strong><dd><code>Preserve declared sensor maximum value constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_base_sensor.py

<ul><li>Preserves maximums declared by sensor definitions<br> <li> Derives unit-based limits only when omitted<br> <li> Adds <code>DEFAULT_MAX_VALUE</code> for non-derivable limits<br> <li> Passes missing maximums as <code>None</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/441/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+20/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_max_value_declaration.py</strong><dd><code>Cover declared maximum and fallback behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_max_value_declaration.py

<ul><li>Tests export register maximum preservation<br> <li> Covers watt, kilowatt, ampere derivation paths<br> <li> Verifies unitless fallback and direct construction<br> <li> Confirms S6-EH3P 20 kW catalogue support</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/441/files#diff-00dbad5ced9ea065d3b4d9ca7ccfd934554ed2e41276e3167509b7a2b271e58a">+155/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

