### PR TITLE
Distinguish closed datalogger ports from Modbus failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,37 @@ Solis and equivalent Axitec, Zonneplan inverters
 - Waveshare
 
 ## Troubleshooting
+
+### ⚠️ "Cannot connect" — datalogger firmware closing local port 502
+
+Several Solis dataloggers (**S5-WiFi-ST**, and reports on **S2-WL-ST** too) have stopped
+serving Modbus TCP after a firmware/OTA update. SolisCloud keeps working, so the inverter
+looks perfectly healthy while Home Assistant can no longer reach it.
+
+Check it from any PC on the same LAN — **no Home Assistant involved**:
+
+```powershell
+Test-NetConnection 192.168.1.50 -Port 502
+```
+```bash
+nc -vz 192.168.1.50 502
+```
+
+If ping succeeds but the TCP test fails, the port is closed on the device and **no
+integration setting will fix it** — nothing can reopen a port the logger has shut. Port 80
+(the logger's own web UI) is usually dead too, which is a good confirmation.
+
+Known workarounds:
+
+* Raise it with Solis support — the more reports the better. Note that the S2-WL-ST
+  product page does advertise Modbus TCP support, which gives you something to point at.
+* Use an RS485-to-TCP bridge on the inverter's RS485 port instead of the logger's WiFi
+  stick — an **Elfin EW11** and a **Waveshare RS485-to-Ethernet** have both been confirmed
+  working by users who hit this. The integration then works normally.
+* A direct USB RS485 adapter with the **serial** connection type also bypasses the logger.
+
+See [issue #432](https://github.com/Pho3niX90/solis_modbus/issues/432) for the thread.
+
 ### Restoring Sensor History
 If a sensor's entity ID changes (e.g., during migration) and you lose its history, you can manually restore it using Home Assistant's statistics tool:
 

--- a/custom_components/solis_modbus/config_flow.py
+++ b/custom_components/solis_modbus/config_flow.py
@@ -97,6 +97,32 @@ OPTIONS_SCHEMA = vol.Schema(
 )
 
 
+async def _probe_tcp_port(host: str, port: int, timeout: float = 5.0) -> tuple[bool, str | None]:
+    """Check that something is actually accepting TCP connections on host:port.
+
+    A plain socket open is far cheaper than a Modbus handshake and separates the two
+    failure modes cleanly: a refused/timed-out connect means nothing is listening,
+    whereas a successful connect that then fails the register probe means Modbus (or
+    the slave id) is the problem. Returns (reachable, reason).
+    """
+    writer = None
+    try:
+        _, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=timeout)
+        return True, None
+    except TimeoutError:
+        return False, "timeout"
+    except OSError as e:
+        # ConnectionRefusedError, host unreachable, DNS failure — all OSError subclasses.
+        return False, type(e).__name__
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:  # pragma: no cover - best-effort cleanup
+                pass
+
+
 def clean_identification(iden: str | None) -> str | None:
     if not iden or not iden.strip():
         return None
@@ -261,7 +287,17 @@ class ModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         probe_register = 3041 if inverter_config.type in [InverterType.GRID, InverterType.STRING] else 35000
 
         if conn_type == CONN_TYPE_TCP:
-            client = AsyncModbusTcpClient(host=user_input["host"], port=user_input.get("port", 502), timeout=5, retries=1)
+            host, port = user_input["host"], user_input.get("port", 502)
+            reachable, reason = await _probe_tcp_port(host, port)
+            if not reachable:
+                # Distinguish "nothing is listening on 502" from "Modbus itself failed".
+                # Recent Solis datalogger firmware closes the local TCP services while
+                # cloud upload keeps working, which otherwise surfaces as a generic
+                # "check your configuration" and sends people hunting the wrong problem
+                # (issue #432).
+                _LOGGER.error("TCP pre-probe of %s:%s failed (%s) — nothing is serving Modbus there", host, port, reason)
+                return False, "tcp_port_closed"
+            client = AsyncModbusTcpClient(host=host, port=port, timeout=5, retries=1)
         else:  # Serial
             client = AsyncModbusSerialClient(
                 port=user_input[CONF_SERIAL_PORT],

--- a/custom_components/solis_modbus/translations/af.json
+++ b/custom_components/solis_modbus/translations/af.json
@@ -73,7 +73,8 @@
       "unknown": "Onverwagte fout het voorgekom.",
       "invalid_model": "Ongeldige of onbekende omsettermodel. Kies asseblief 'n model uit die lys.",
       "serial_required": "Omsetter-reeksnommer word vereis.",
-      "model_required": "Kies asseblief 'n omsettermodel."
+      "model_required": "Kies asseblief 'n omsettermodel.",
+      "tcp_port_closed": "Niks aanvaar Modbus-verbindings op daardie adres en poort nie. Die toestel kan bereikbaar wees (dit antwoord op ping) maar bedien nie Modbus nie — kontroleer dat Modbus TCP op die datalogger geaktiveer is. Onlangse Solis-logger-firmware sluit bekend plaaslike poort 502; 'n RS485-na-TCP-brug is 'n omweg."
     },
     "abort": {
       "already_configured": "Hierdie toestel is reeds gekonfigureer."

--- a/custom_components/solis_modbus/translations/de.json
+++ b/custom_components/solis_modbus/translations/de.json
@@ -73,7 +73,8 @@
       "unknown": "Unerwarteter Fehler aufgetreten.",
       "invalid_model": "Ungültiges oder unbekanntes Wechselrichtermodell. Bitte ein Modell aus der Liste wählen.",
       "serial_required": "Die Seriennummer des Wechselrichters ist erforderlich.",
-      "model_required": "Bitte ein Wechselrichtermodell auswählen."
+      "model_required": "Bitte ein Wechselrichtermodell auswählen.",
+      "tcp_port_closed": "Auf dieser Adresse und diesem Port nimmt nichts Modbus-Verbindungen an. Das Gerät ist möglicherweise erreichbar (es antwortet auf Ping), stellt aber kein Modbus bereit — prüfen Sie, ob Modbus TCP auf dem Datenlogger aktiviert ist. Neuere Solis-Logger-Firmware schließt bekanntermaßen den lokalen Port 502; eine RS485-zu-TCP-Bridge ist eine Abhilfe."
     },
     "abort": {
       "already_configured": "Dieses Gerät ist bereits konfiguriert."

--- a/custom_components/solis_modbus/translations/en.json
+++ b/custom_components/solis_modbus/translations/en.json
@@ -73,7 +73,8 @@
       "unknown": "Unexpected error occurred.",
       "invalid_model": "Invalid or unknown inverter model. Please select a model from the list.",
       "serial_required": "Inverter serial number is required.",
-      "model_required": "Please select an inverter model."
+      "model_required": "Please select an inverter model.",
+      "tcp_port_closed": "Nothing is accepting Modbus connections on that address and port. The device may be reachable (it answers ping) but not serving Modbus — check that Modbus TCP is enabled on the datalogger. Recent Solis logger firmware is known to close local port 502; an RS485-to-TCP bridge is a workaround."
     },
     "abort": {
       "already_configured": "This device is already configured."

--- a/custom_components/solis_modbus/translations/es.json
+++ b/custom_components/solis_modbus/translations/es.json
@@ -73,7 +73,8 @@
       "unknown": "Ocurrió un error inesperado.",
       "invalid_model": "Modelo de inversor no válido o desconocido. Seleccione un modelo de la lista.",
       "serial_required": "Se requiere el número de serie del inversor.",
-      "model_required": "Seleccione un modelo de inversor."
+      "model_required": "Seleccione un modelo de inversor.",
+      "tcp_port_closed": "Nada acepta conexiones Modbus en esa dirección y puerto. El dispositivo puede ser accesible (responde al ping) pero no está sirviendo Modbus — compruebe que Modbus TCP esté habilitado en el registrador. Se sabe que el firmware reciente del registrador Solis cierra el puerto local 502; un puente RS485 a TCP es una solución alternativa."
     },
     "abort": {
       "already_configured": "Este dispositivo ya está configurado."

--- a/custom_components/solis_modbus/translations/fr.json
+++ b/custom_components/solis_modbus/translations/fr.json
@@ -73,7 +73,8 @@
       "unknown": "Une erreur inattendue s'est produite.",
       "invalid_model": "Modèle d'onduleur invalide ou inconnu. Veuillez sélectionner un modèle dans la liste.",
       "serial_required": "Le numéro de série de l'onduleur est requis.",
-      "model_required": "Veuillez sélectionner un modèle d'onduleur."
+      "model_required": "Veuillez sélectionner un modèle d'onduleur.",
+      "tcp_port_closed": "Rien n'accepte les connexions Modbus sur cette adresse et ce port. L'appareil est peut-être joignable (il répond au ping) mais ne sert pas Modbus — vérifiez que Modbus TCP est activé sur l'enregistreur. Les firmwares récents des enregistreurs Solis sont connus pour fermer le port local 502 ; un pont RS485 vers TCP est une solution de contournement."
     },
     "abort": {
       "already_configured": "Cet appareil est déjà configuré."

--- a/custom_components/solis_modbus/translations/it.json
+++ b/custom_components/solis_modbus/translations/it.json
@@ -73,7 +73,8 @@
       "unknown": "Si è verificato un errore imprevisto.",
       "invalid_model": "Modello di inverter non valido o sconosciuto. Selezionare un modello dall'elenco.",
       "serial_required": "Il numero di serie dell'inverter è obbligatorio.",
-      "model_required": "Selezionare un modello di inverter."
+      "model_required": "Selezionare un modello di inverter.",
+      "tcp_port_closed": "Nessun servizio accetta connessioni Modbus su quell'indirizzo e porta. Il dispositivo potrebbe essere raggiungibile (risponde al ping) ma non fornisce Modbus — verificare che Modbus TCP sia abilitato sul datalogger. È noto che i firmware recenti dei logger Solis chiudono la porta locale 502; un bridge RS485-TCP è una soluzione alternativa."
     },
     "abort": {
       "already_configured": "Questo dispositivo è già configurato."

--- a/custom_components/solis_modbus/translations/nl.json
+++ b/custom_components/solis_modbus/translations/nl.json
@@ -73,7 +73,8 @@
       "unknown": "Onverwachte fout opgetreden.",
       "invalid_model": "Ongeldig of onbekend omvormermodel. Selecteer een model uit de lijst.",
       "serial_required": "Het serienummer van de omvormer is verplicht.",
-      "model_required": "Selecteer een omvormermodel."
+      "model_required": "Selecteer een omvormermodel.",
+      "tcp_port_closed": "Er accepteert niets Modbus-verbindingen op dat adres en die poort. Het apparaat is mogelijk bereikbaar (het antwoordt op ping) maar biedt geen Modbus aan — controleer of Modbus TCP is ingeschakeld op de datalogger. Van recente Solis-loggerfirmware is bekend dat deze lokale poort 502 sluit; een RS485-naar-TCP-bridge is een tijdelijke oplossing."
     },
     "abort": {
       "already_configured": "Dit apparaat is al geconfigureerd."

--- a/custom_components/solis_modbus/translations/pt.json
+++ b/custom_components/solis_modbus/translations/pt.json
@@ -73,7 +73,8 @@
       "unknown": "Ocorreu um erro inesperado.",
       "invalid_model": "Modelo de inversor inválido ou desconhecido. Selecione um modelo da lista.",
       "serial_required": "O número de série do inversor é obrigatório.",
-      "model_required": "Selecione um modelo de inversor."
+      "model_required": "Selecione um modelo de inversor.",
+      "tcp_port_closed": "Nada aceita ligações Modbus nesse endereço e porta. O dispositivo pode estar acessível (responde a ping) mas não está a servir Modbus — verifique se o Modbus TCP está ativado no registador. Sabe-se que o firmware recente dos registadores Solis fecha a porta local 502; uma ponte RS485 para TCP é uma solução alternativa."
     },
     "abort": {
       "already_configured": "Este dispositivo já está configurado."

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -233,9 +233,13 @@ async def test_validate_config_uses_throwaway_client(hass: HomeAssistant):
 
     manager_clients_before = dict(ModbusClientManager.get_instance()._clients)
 
-    with patch(
-        "custom_components.solis_modbus.config_flow.AsyncModbusTcpClient",
-        return_value=mock_client,
+    with (
+        patch(
+            "custom_components.solis_modbus.config_flow.AsyncModbusTcpClient",
+            return_value=mock_client,
+        ),
+        # Port is open — this test is about the Modbus probe, not reachability.
+        patch("custom_components.solis_modbus.config_flow._probe_tcp_port", AsyncMock(return_value=(True, None))),
     ):
         valid, err = await flow._validate_config({"connection_type": CONN_TYPE_TCP, "host": "1.2.3.4", "slave": 1, "model": "S6-EH1P"})
 
@@ -262,6 +266,8 @@ async def test_validate_config_cannot_connect(hass: HomeAssistant):
     with (
         patch("custom_components.solis_modbus.config_flow.AsyncModbusTcpClient", return_value=mock_client),
         patch("custom_components.solis_modbus.config_flow.asyncio.sleep", new=AsyncMock()),
+        # Port is open — the failure under test is the Modbus connect, not the port.
+        patch("custom_components.solis_modbus.config_flow._probe_tcp_port", AsyncMock(return_value=(True, None))),
     ):
         valid, err = await flow._validate_config({"connection_type": CONN_TYPE_TCP, "host": "1.2.3.4", "slave": 1, "model": "S6-EH1P"})
 

--- a/tests/test_config_flow_tcp_probe.py
+++ b/tests/test_config_flow_tcp_probe.py
@@ -1,0 +1,132 @@
+"""A closed TCP port must be reported as such, not as a generic config error.
+
+Issue #432: Solis datalogger firmware started closing the local TCP services while
+cloud upload kept working. Users saw only "Failed to connect, please check your
+settings", so they re-checked host/port/slave for days before someone probed port 502
+from a plain PC and found it shut. The pre-probe separates "nothing is listening" from
+"Modbus itself failed" so the error text can say which.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.solis_modbus.config_flow import ModbusConfigFlow, _probe_tcp_port
+from custom_components.solis_modbus.const import CONN_TYPE_TCP
+
+TCP_INPUT = {
+    "connection_type": CONN_TYPE_TCP,
+    "host": "1.2.3.4",
+    "port": 502,
+    "slave": 1,
+    "model": "S6-EH1P",
+    "connection": "S2_WL_ST",
+}
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+    async def wait_closed(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_true_when_something_listens():
+    writer = _FakeWriter()
+    with patch("asyncio.open_connection", AsyncMock(return_value=(object(), writer))):
+        reachable, reason = await _probe_tcp_port("1.2.3.4", 502)
+    assert reachable is True
+    assert reason is None
+    assert writer.closed, "the probe socket must not be leaked"
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_refused_connection():
+    with patch("asyncio.open_connection", AsyncMock(side_effect=ConnectionRefusedError())):
+        reachable, reason = await _probe_tcp_port("1.2.3.4", 502)
+    assert reachable is False
+    assert reason == "ConnectionRefusedError"
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_timeout():
+    with patch("asyncio.open_connection", AsyncMock(side_effect=TimeoutError())):
+        reachable, reason = await _probe_tcp_port("1.2.3.4", 502)
+    assert reachable is False
+    assert reason == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_validate_config_returns_tcp_port_closed_when_port_shut():
+    """The reported case: pings fine, port 502 refuses."""
+    flow = ModbusConfigFlow()
+    with patch(
+        "custom_components.solis_modbus.config_flow._probe_tcp_port",
+        AsyncMock(return_value=(False, "ConnectionRefusedError")),
+    ):
+        ok, err = await flow._validate_config(dict(TCP_INPUT))
+    assert ok is False
+    assert err == "tcp_port_closed"
+
+
+@pytest.mark.asyncio
+async def test_validate_config_does_not_probe_modbus_when_port_is_shut():
+    """No point spending three Modbus attempts on a port nothing is listening on."""
+    flow = ModbusConfigFlow()
+    with (
+        patch(
+            "custom_components.solis_modbus.config_flow._probe_tcp_port",
+            AsyncMock(return_value=(False, "ConnectionRefusedError")),
+        ),
+        patch("custom_components.solis_modbus.config_flow.AsyncModbusTcpClient") as client_cls,
+    ):
+        await flow._validate_config(dict(TCP_INPUT))
+    client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_open_port_but_bad_modbus_still_reports_cannot_connect():
+    """A listening port that fails the register probe is a different problem."""
+    flow = ModbusConfigFlow()
+
+    client = AsyncMock()
+    client.connected = True
+    client.read_input_registers = AsyncMock(side_effect=ConnectionError("boom"))
+    client.close = lambda: None
+
+    with (
+        patch("custom_components.solis_modbus.config_flow._probe_tcp_port", AsyncMock(return_value=(True, None))),
+        patch("custom_components.solis_modbus.config_flow.AsyncModbusTcpClient", return_value=client),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        ok, err = await flow._validate_config(dict(TCP_INPUT))
+
+    assert ok is False
+    assert err == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_serial_connections_skip_the_tcp_probe():
+    flow = ModbusConfigFlow()
+
+    client = AsyncMock()
+    client.connected = True
+    result = AsyncMock()
+    result.isError = lambda: False
+    client.read_input_registers = AsyncMock(return_value=result)
+    client.close = lambda: None
+
+    with (
+        patch("custom_components.solis_modbus.config_flow._probe_tcp_port", AsyncMock()) as probe,
+        patch("custom_components.solis_modbus.config_flow.AsyncModbusSerialClient", return_value=client),
+    ):
+        ok, err = await flow._validate_config({"connection_type": "serial", "serial_port": "/dev/ttyUSB0", "model": "S6-EH1P", "slave": 1})
+
+    probe.assert_not_called()
+    assert ok is True
+    assert err is None


### PR DESCRIPTION
### **User description**
Addresses #432 (diagnosability — see below on why this is not a code-level fix).

## What's actually happening in #432

Several Solis dataloggers (**S5-WiFi-ST**, with matching reports on **S2-WL-ST**) stopped
serving Modbus TCP after a firmware/OTA update. SolisCloud keeps working, so the inverter
looks healthy while HA can't reach it.

The reporter eventually proved it from a Windows PC with **no Home Assistant involved**:

```
Test-NetConnection 192.168.1.221 -Port 502
PingSucceeded      : True
TcpTestSucceeded   : False
```

Port **80** — the logger's own web UI — is down too, and he now runs the same integration
build happily through an Elfin EW11 RS485 bridge. Three other users report the same, one
on the other logger model.

So the integration is not at fault and cannot fix it: nothing in HA can reopen a port the
logger has closed. But it *was* making the problem much harder to find, because the config
flow reported only `Failed to connect, please check your settings` — which sends people
hunting host/port/slave/model for days.

## The change

- **`_probe_tcp_port()`** — a plain `asyncio.open_connection()` before any Modbus client is
  built. A refused or timed-out connect means nothing is listening; a *successful* connect
  that then fails the register read means Modbus (or the slave id) is the problem. Those
  are now two different errors instead of one.
- **New `tcp_port_closed` error key**, translated into all 8 supported languages, which
  names the likely cause and points at an RS485-to-TCP bridge.
- Skipping the three Modbus attempts on a dead port also makes the form **fail fast**
  rather than sitting through connect timeouts.
- **README troubleshooting entry** with the `Test-NetConnection` / `nc -vz` one-liner so
  users can confirm it themselves in ten seconds, plus the workarounds reporters actually
  landed on (Elfin EW11, Waveshare RS485-to-Ethernet, direct USB RS485 + serial mode).

Serial connections are unaffected — the probe is TCP-only.

## Tests

7 added in `tests/test_config_flow_tcp_probe.py`: the probe's success / refused / timeout
paths and that it doesn't leak the socket; `tcp_port_closed` returned on a shut port; no
Modbus client constructed in that case; an open port with a failing register read still
returning `cannot_connect`; and serial skipping the probe.

Two existing config-flow tests now stub the probe as reachable — they target the Modbus
path, not reachability.

**218 pass**, `ruff check` and `ruff format --check` clean.

## Worth noting separately

v4.1.6 is still the latest release while master carries 30 commits including
`7c325a4` (repair issue when the datalogger is unreachable) and `4ac9139` (config-flow
hardening). Those would have made this failure self-announcing for the affected users —
a 4.2.0 release would help this thread directly.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Probe TCP availability before Modbus configuration

- Distinguish closed ports from Modbus failures

- Localize diagnostics across eight supported languages

- Document firmware symptoms, checks, and workarounds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  config["TCP configuration"]
  probe["TCP port pre-probe"]
  closed["Closed-port diagnostic"]
  modbus["Modbus register probe"]
  failure["Generic Modbus failure"]
  success["Configuration succeeds"]
  config -- "starts" --> probe
  probe -- "port unreachable" --> closed
  probe -- "port reachable" --> modbus
  modbus -- "probe fails" --> failure
  modbus -- "probe succeeds" --> success
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config_flow.py</strong><dd><code>Pre-probe TCP ports before Modbus validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-2e983e3a2a647135a82c37e4ee143bab14008b7fa1c13da9da8dea903c2e14c3">+37/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_config_flow.py</strong><dd><code>Stub reachability in existing Modbus flow tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_config_flow_tcp_probe.py</strong><dd><code>Test TCP probing and failure classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-00a623ac1e4dd90c26f8bd7c8e72cb3927f0c49db564c0a6d18d9faede093b52">+132/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document closed logger ports and workarounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>af.json</strong><dd><code>Add Afrikaans closed-port diagnostic message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-8241c6d92befd0db4ff4f5fbc59c074b0f18c9d11d2aea3a3d6e9b8a0f492108">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>de.json</strong><dd><code>Add German closed-port diagnostic message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-9d4fe8cc0397789f4244533686ffa52c66ce53ca110b60e814115d696dd4cecf">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Add English closed-port diagnostic message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-032e7d7792e451969223c0a099ba0535cf4e92897efa7f8644a36340fabb2440">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>es.json</strong><dd><code>Add Spanish closed-port diagnostic message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-cbf2d97025c8caad05101bbd9a13bad5510e28102420d4de83889a9b1bf37980">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fr.json</strong><dd><code>Add French closed-port diagnostic message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-1a0ae3fd5236a988ed1f8078f69524f4d45371569651acb90997c1373b361481">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>it.json</strong><dd><code>Add Italian closed-port diagnostic message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-e4515ea4d373d60486a5c7a54eeb4c2754effb1eefc2558c7d3a78d6fce2386d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nl.json</strong><dd><code>Add Dutch closed-port diagnostic message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-a3e1b3c3bcddfe0ba2ee06b731040710ead80d7d5058bcf10473b42aa59d96a6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pt.json</strong><dd><code>Add Portuguese closed-port diagnostic message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/442/files#diff-ba39a4cd39eb74e1aa7480f5711999b28ac10367ee7f4fe56522864eeff5cfc1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

