### PR TITLE
Fix HV-battery setup crash from missing sensor steps

### DIFF
--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -109,7 +109,11 @@ class SolisBaseSensor:
             hv_battery_sensitive_regs = {33205, 33206, 33207, 43013, 43117}
             if _any_in(self.registrars, hv_battery_sensitive_regs):
                 self.min_value = 0
-                self.step = min(self.step, 0.1)
+                # get_step() only derives a step for %, kW and W, so anything else
+                # arrives as None. These registers include amp-denominated ones
+                # (33206/33207), where min(None, 0.1) raised and took the whole
+                # entry down on HV-battery inverters (#445, #446, #447).
+                self.step = 0.1 if self.step is None else min(self.step, 0.1)
 
         # RHI/RAI models: 1 <--> 1W (range: 0–30000)
         if inv_model in {"RHI-1P", "RHI-3P", "RAI-3K-48ES-5G"} and 43074 in self.registrars:
@@ -157,6 +161,8 @@ class SolisBaseSensor:
             return 0.1
         if self.unit_of_measurement == UnitOfPower.WATT:
             return 1
+        # Anything else has no sensible derived step; callers must cope with None.
+        return None
 
     @property
     def entity_category(self) -> EntityCategory | None:

--- a/tests/test_hv_battery_step.py
+++ b/tests/test_hv_battery_step.py
@@ -1,0 +1,113 @@
+"""Regression tests for the HV-battery step adjustment.
+
+v4.2.0 added amp-denominated sensors on registers 33206/33207, which sit inside
+the HV-battery branch of ``dynamic_adjustments``. That branch narrowed the step
+with ``min(self.step, 0.1)``, but ``get_step`` only derives a step for %, kW and
+W -- amps arrive as ``None``. The result was a TypeError during setup that took
+the entire config entry down on HV-battery inverters (#445, #446, #447).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent, UnitOfPower
+
+from custom_components.solis_modbus.data.enums import InverterType
+from custom_components.solis_modbus.data.solis_config import (
+    InverterConfig,
+    InverterOptions,
+)
+from custom_components.solis_modbus.sensors.solis_base_sensor import SolisBaseSensor
+
+
+def _controller(hv_battery: bool):
+    """A controller whose inverter may or may not have an HV battery."""
+    controller = MagicMock()
+    controller.inverter_config = InverterConfig(
+        model="S6-EH3P",
+        wattage=[10000],
+        phases=3,
+        type=InverterType.HYBRID,
+        options=InverterOptions(hv_battery=hv_battery),
+    )
+    controller.inverter_config.wattage_chosen = 10000
+    return controller
+
+
+def _sensor(controller, register: str, unit, step=None):
+    """Build a sensor the way SolisSensorGroup does.
+
+    Note ``step=None``: the group passes ``entity.get("step", None)``, so a
+    definition that declares no step overrides the constructor default rather
+    than inheriting it. That is what makes this reachable at all.
+    """
+    return SolisBaseSensor(
+        hass=MagicMock(),
+        controller=controller,
+        unique_id="test",
+        name="Test",
+        registrars=[int(register)],
+        write_register=None,
+        multiplier=1,
+        unit_of_measurement=unit,
+        step=step,
+    )
+
+
+class TestHvBatteryStep:
+    @pytest.mark.parametrize("register", ["33206", "33207"])
+    def test_amp_sensors_do_not_crash_setup(self, register):
+        """The exact failure from #445/#446/#447."""
+        sensor = _sensor(_controller(hv_battery=True), register, UnitOfElectricCurrent.AMPERE)
+
+        assert sensor.step == 0.1, "an undeclared step must fall back, not raise"
+        assert sensor.min_value == 0
+
+    def test_a_declared_step_is_still_narrowed(self):
+        """The branch exists to tighten the step; that must keep working."""
+        sensor = _sensor(_controller(hv_battery=True), "33206", UnitOfElectricCurrent.AMPERE, step=1)
+
+        assert sensor.step == 0.1
+
+    def test_a_finer_declared_step_is_preserved(self):
+        """min() means finer-than-0.1 wins; don't coarsen someone's sensor."""
+        sensor = _sensor(
+            _controller(hv_battery=True),
+            "33206",
+            UnitOfElectricCurrent.AMPERE,
+            step=0.01,
+        )
+
+        assert sensor.step == 0.01
+
+    def test_non_hv_inverters_are_untouched(self):
+        """Without an HV battery the branch must not run at all."""
+        sensor = _sensor(_controller(hv_battery=False), "33206", UnitOfElectricCurrent.AMPERE)
+
+        assert sensor.step is None
+
+    def test_unrelated_registers_are_untouched(self):
+        """Only the listed registers are HV-sensitive."""
+        sensor = _sensor(_controller(hv_battery=True), "33000", UnitOfElectricCurrent.AMPERE)
+
+        assert sensor.step is None
+
+
+class TestGetStep:
+    @pytest.mark.parametrize(
+        ("unit", "expected"),
+        [
+            (PERCENTAGE, 1),
+            (UnitOfPower.KILO_WATT, 0.1),
+            (UnitOfPower.WATT, 1),
+            (UnitOfElectricCurrent.AMPERE, None),
+        ],
+    )
+    def test_derived_steps(self, unit, expected):
+        """Amps deriving to None is intended; callers must cope with it."""
+        assert _sensor(_controller(hv_battery=False), "33000", unit).step == expected
+
+    def test_a_declared_step_always_wins(self):
+        sensor = _sensor(_controller(hv_battery=False), "33000", PERCENTAGE, step=5)
+
+        assert sensor.step == 5

--- a/tests/test_sensor_construction_matrix.py
+++ b/tests/test_sensor_construction_matrix.py
@@ -1,0 +1,132 @@
+"""Every sensor definition must construct for every inverter feature set.
+
+This is a guard against a class of bug rather than a specific one. v4.2.0
+shipped a crash that only appeared on HV-battery hardware: new amp-denominated
+sensors landed on registers that a model-specific branch narrowed the step for,
+and the step could be None. Nobody could have caught it by running the
+integration, because it needs an HV battery to reach the branch at all
+(#445, #446, #447).
+
+Sensor definitions are static data, so the whole matrix can be built in-process
+without any hardware. If a definition and a feature branch ever disagree again,
+this fails in CI instead of on a user's inverter.
+"""
+
+import itertools
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solis_modbus.data.enums import InverterType
+from custom_components.solis_modbus.data.solis_config import (
+    SOLIS_INVERTERS,
+    InverterConfig,
+    InverterOptions,
+)
+from custom_components.solis_modbus.sensor_data.hybrid_sensors import hybrid_sensors
+from custom_components.solis_modbus.sensor_data.string_sensors import string_sensors
+from custom_components.solis_modbus.sensors.solis_base_sensor import SolisSensorGroup
+
+# The options a user can actually toggle, which is what decides the feature set.
+TOGGLES = ("hv_battery", "ac_coupling", "parallel", "dual_meter", "epm", "generator")
+
+
+def _controller(**options):
+    controller = MagicMock()
+    config = InverterConfig(
+        model="S6-EH3P",
+        wattage=[10000],
+        phases=3,
+        type=InverterType.HYBRID,
+        options=InverterOptions(**options),
+    )
+    config.wattage_chosen = 10000
+    controller.inverter_config = config
+    return controller
+
+
+def _all_groups():
+    """Only the polled register groups.
+
+    Derived sensors are computed from other entities and never go through
+    SolisSensorGroup, so they have no registers to build a group from.
+    """
+    return list(hybrid_sensors) + list(string_sensors)
+
+
+def _build(controller, group):
+    """Build one group the way async_setup_entry does."""
+    return SolisSensorGroup(hass=MagicMock(), definition=group, controller=controller, identification=None)
+
+
+@pytest.mark.parametrize("hv_battery", [True, False], ids=["hv", "lv"])
+def test_every_group_builds_for_hv_and_lv(hv_battery):
+    """The exact shape of the v4.2.0 regression: HV-only code paths."""
+    controller = _controller(hv_battery=hv_battery)
+    failures = []
+
+    for group in _all_groups():
+        try:
+            _build(controller, group)
+        except Exception as error:  # noqa: BLE001 - collecting, not handling
+            name = group.get("name", group.get("register_start", "?"))
+            failures.append(f"{name}: {type(error).__name__}: {error}")
+
+    assert not failures, "sensor groups failed to build:\n  " + "\n  ".join(failures)
+
+
+@pytest.mark.parametrize(
+    "combo",
+    list(itertools.product([True, False], repeat=len(TOGGLES))),
+    ids=lambda c: "".join(t[0].upper() if v else "-" for t, v in zip(TOGGLES, c)),
+)
+def test_every_group_builds_for_every_option_combination(combo):
+    """All 64 combinations of the user-facing options."""
+    controller = _controller(**dict(zip(TOGGLES, combo)))
+
+    for group in _all_groups():
+        try:
+            _build(controller, group)
+        except Exception as error:  # noqa: BLE001
+            name = group.get("name", group.get("register_start", "?"))
+            pytest.fail(f"{name} failed with {dict(zip(TOGGLES, combo))}: {error!r}")
+
+
+@pytest.mark.parametrize("template", SOLIS_INVERTERS, ids=lambda t: t.model)
+def test_every_shipped_inverter_model_builds(template):
+    """Each model in SOLIS_INVERTERS, with HV battery on -- the risky path."""
+    config = InverterConfig(
+        model=template.model,
+        wattage=list(template.wattage),
+        phases=template.phases,
+        type=template.type,
+        options=InverterOptions(hv_battery=True),
+    )
+    config.wattage_chosen = template.wattage[0]
+    controller = MagicMock()
+    controller.inverter_config = config
+
+    for group in _all_groups():
+        try:
+            _build(controller, group)
+        except Exception as error:  # noqa: BLE001
+            name = group.get("name", group.get("register_start", "?"))
+            pytest.fail(f"{template.model} / {name}: {error!r}")
+
+
+def test_no_sensor_ends_up_with_an_unusable_step():
+    """A step must be a number or absent -- never something arithmetic breaks on.
+
+    The v4.2.0 crash was `min(None, 0.1)`. Anything that leaves a step in a
+    state later maths can't handle should fail here first.
+    """
+    bad = []
+
+    for hv in (True, False):
+        controller = _controller(hv_battery=hv)
+        for group in _all_groups():
+            for sensor in _build(controller, group)._sensors:
+                if sensor.step is not None and not isinstance(sensor.step, (int, float)):
+                    bad.append(f"{sensor.name} (hv={hv}): step={sensor.step!r}")
+
+    assert not bad, "sensors with an unusable step:\n  " + "\n  ".join(bad)


### PR DESCRIPTION
### **User description**
Hotfix for three reports that v4.2.0 will not set up on HV-battery inverters. The config entry goes to `setup_error` and every entity disappears, so this takes the whole integration down for affected users. Reported in #445, #446 and #447; all three downgraded to v4.1.6 to recover.

```
File ".../sensors/solis_base_sensor.py", line 112, in dynamic_adjustments
    self.step = min(self.step, 0.1)
TypeError: '<' not supported between instances of 'float' and 'NoneType'
```

## Cause

Two things that were each fine on their own:

- `dynamic_adjustments()` narrows the step for registers in the HV-battery set `{33205, 33206, 33207, 43013, 43117}` using `min(self.step, 0.1)`.
- `get_step()` only derives a step for `%`, `kW` and `W` — anything else falls through and returns `None`. `SolisSensorGroup` passes `step=entity.get("step", None)`, so a definition declaring no step overrides the constructor's `0.1` default.

Nothing in that register set was amp-denominated until v4.2.0, when **my** #443 added *Battery Max Charge/Discharge Current Mirror* on 33206 and 33207 — both in amps, neither declaring a step. `min(None, 0.1)` then raises during setup.

Only HV-battery inverters enter the branch, which is why it did not surface on non-HV hardware. My own S5-EH1P has `has_hv_battery: False`, so I could not have hit this before release. Apologies — that one is on me.

## Fix

```python
self.step = 0.1 if self.step is None else min(self.step, 0.1)
```

Falls back to `0.1` when nothing could be derived, and keeps the narrowing behaviour where a step *is* declared. Also makes `get_step()` return `None` explicitly rather than falling off the end, so the next reader can see callers must handle it.

## Tests

Adds `tests/test_hv_battery_step.py` — 11 tests. Verified they **fail on current master** with the users' exact `TypeError` on both 33206 and 33207, and pass with the fix. Full suite: **268 passed**.

Covered: the crash itself on both registers; a declared step is still narrowed to 0.1; a finer declared step (0.01) is preserved rather than coarsened; non-HV inverters and unrelated registers are untouched; and `get_step()`'s derivation table including the `None` fall-through.

## Credit

@gresie, @Gammaed and @petervanderwaal1982 reported it. @petervanderwaal1982 diagnosed the root cause precisely and verified this exact one-line change on HV hardware (2× Dyness Tower T10) before I wrote anything — the analysis in #447 is what this is built on.

Worth a v4.2.1 fairly promptly, since anyone on HV battery who updates loses the integration entirely.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prevent HV-battery sensor setup crashes

- Default missing sensitive-register steps to `0.1`

- Explicitly return `None` for underived steps

- Cover step adjustment behavior with regression tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  sensor["HV-battery sensor initialization"]
  derive["Derive sensor step"]
  fallback["Apply 0.1 fallback"]
  setup["Complete integration setup"]
  sensor -- "step unavailable" --> derive
  derive -- "returns None" --> fallback
  fallback -- "prevents TypeError" --> setup
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_base_sensor.py</strong><dd><code>Safeguard HV-battery sensor step adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_base_sensor.py

<ul><li>Handles <code>None</code> before narrowing HV-battery steps<br> <li> Defaults affected amp sensors to <code>0.1</code><br> <li> Explicitly returns <code>None</code> for unsupported units</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/448/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_hv_battery_step.py</strong><dd><code>Add HV-battery step regression coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_hv_battery_step.py

<ul><li>Reproduces setup failures for registers <code>33206</code> and <code>33207</code><br> <li> Tests declared, finer, and fallback steps<br> <li> Verifies non-HV and unrelated sensors remain unchanged<br> <li> Covers derived and explicitly configured steps</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/448/files#diff-aeffe37444553537c67043a7d12fb2139a9656acbcc85eda31c72804bd92d7a8">+113/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HV-battery sensor handling when measurement step information is unavailable.
  - Sensors now use a safe default step instead of encountering an error.
  - Preserved explicitly configured and more precise measurement steps.

- **Tests**
  - Added coverage for HV-battery step handling across inverter types, units, and configuration options.
  - Added validation to ensure constructed sensors have usable step values across supported sensor configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->