### PR TITLE
Fix HV-battery setup crash from missing sensor step

### DIFF
--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -109,7 +109,7 @@ class SolisBaseSensor:
             hv_battery_sensitive_regs = {33205, 33206, 33207, 43013, 43117}
             if _any_in(self.registrars, hv_battery_sensitive_regs):
                 self.min_value = 0
-                self.step = min(self.step, 0.1)
+                self.step = 0.1 if self.step is None else min(self.step, 0.1)
 
         # RHI/RAI models: 1 <--> 1W (range: 0–30000)
         if inv_model in {"RHI-1P", "RHI-3P", "RAI-3K-48ES-5G"} and 43074 in self.registrars:


### PR DESCRIPTION
### **User description**
On HV-battery inverters, `dynamic_adjustments()` runs `self.step = min(self.step, 0.1)` for sensors on `{33205, 33206, 33207, 43013, 43117}`. `get_step()` returns `None` for any unit that isn't %/kW/W (e.g. the new battery-current registers in A), so `min(None, 0.1)` raises `TypeError` and the whole config entry fails setup — every entity disappears. This guards against `None`.

## Related Issues

Closes #447 
## Testing Steps

**Tested with:** Solis S6-EH3P10K-H V2 + Dyness HV (2× Tower T10), Modbus TCP via the datalogger.

**Before:** v4.2.0 fails `async_setup_entry` with the TypeError above; the entry goes to `setup_error`.

**After this change:** integration loads cleanly, all entities + services return; `solis_dispatch mode: battery_hold` and the `34502` capability read both verified working (battery held from −3363 W to −29 W, telemetry followed the command, clean release).

## Additional Notes

Minimal None-guard; `get_step()` returning a non-`None` default would be an equivalent fix. HV-battery-only path, so LV setups are unaffected.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent HV-battery sensor setup crashes

- Default missing sensor steps to `0.1`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  hvSensor["HV-battery sensor"] -- "has no configured step" --> adjustment["Dynamic adjustments"]
  adjustment -- "defaults step to 0.1" --> setup["Successful integration setup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_base_sensor.py</strong><dd><code>Guard missing HV-battery sensor step values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_base_sensor.py

<ul><li>Guard <code>self.step</code> against <code>None</code><br> <li> Apply <code>0.1</code> default for sensitive HV registers<br> <li> Preserve smaller explicitly configured step values</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/449/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for HV battery-sensitive sensors when step information is unavailable.
  * Sensors now use a safe default value and continue operating without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->