### PR TITLE
Handle rejected Modbus register addresses gracefully

### DIFF
--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -276,9 +276,7 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry):
                     f"The inverter has no {register_type} register at {address} (count {count}). "
                     f'If you are probing a documented address, try register_type: "{other}".'
                 )
-            raise HomeAssistantError(
-                f"Read of {register_type} register {address} (count {count}) failed — see logs"
-            )
+            raise HomeAssistantError(f"Read of {register_type} register {address} (count {count}) failed — see logs")
 
         response = {
             "address": address,

--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     DEFAULT_PARITY,
     DEFAULT_STOPBITS,
     DOMAIN,
+    MODBUS_ILLEGAL_DATA_ADDRESS,
 )
 from .data.solis_config import SOLIS_INVERTERS, InverterConfig, InverterType, inverter_options_from_config
 from .data_retrieval import DataRetrieval
@@ -259,13 +260,25 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry):
         register_type = call.data.get("register_type", "input")
         controller = _resolve_controller(call)
 
+        # Use the detailed variants so a Modbus exception code survives: an
+        # inverter rejecting the address is the caller's mistake (usually asking
+        # for a holding register as "input"), not a failure of the integration,
+        # and should not surface as an unhandled 500 (#447).
         if register_type == "holding":
-            values = await controller.async_read_holding_register(address, count)
+            values, exception_code = await controller.async_read_holding_registers_with_exception(address, count)
         else:
-            values = await controller.async_read_input_register(address, count)
+            values, exception_code = await controller.async_read_input_registers_with_exception(address, count)
 
         if values is None:
-            raise HomeAssistantError(f"Read of {register_type} register {address} (count {count}) failed — see logs")
+            if exception_code == MODBUS_ILLEGAL_DATA_ADDRESS:
+                other = "input" if register_type == "holding" else "holding"
+                raise ServiceValidationError(
+                    f"The inverter has no {register_type} register at {address} (count {count}). "
+                    f'If you are probing a documented address, try register_type: "{other}".'
+                )
+            raise HomeAssistantError(
+                f"Read of {register_type} register {address} (count {count}) failed — see logs"
+            )
 
         response = {
             "address": address,

--- a/custom_components/solis_modbus/const.py
+++ b/custom_components/solis_modbus/const.py
@@ -33,3 +33,7 @@ DEFAULT_BAUDRATE = 9600
 DEFAULT_BYTESIZE = 8
 DEFAULT_PARITY = "N"
 DEFAULT_STOPBITS = 1
+
+# Modbus exception code 2: the slave has no register at the requested address.
+# Distinguishes "you asked for the wrong thing" from "the read failed".
+MODBUS_ILLEGAL_DATA_ADDRESS = 2

--- a/tests/test_read_register_service.py
+++ b/tests/test_read_register_service.py
@@ -1,0 +1,65 @@
+"""Tests for the solis_read_register debugging service.
+
+The service is used for probing undocumented registers, so getting the address
+or register type wrong is routine rather than exceptional. It should say so
+plainly instead of surfacing as an unhandled server error (#447).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from custom_components.solis_modbus.const import MODBUS_ILLEGAL_DATA_ADDRESS
+
+
+class TestErrorClassification:
+    """A caller mistake is a validation error; a failed read is not."""
+
+    def test_illegal_address_is_a_validation_error(self):
+        """ServiceValidationError, so callers get a 400 and a readable message."""
+        assert issubclass(ServiceValidationError, HomeAssistantError)
+
+    def test_the_modbus_code_is_the_documented_one(self):
+        """Exception code 2 is 'illegal data address' in the Modbus spec."""
+        assert MODBUS_ILLEGAL_DATA_ADDRESS == 2
+
+
+class TestReadOutcomes:
+    """Exercising the three outcomes the handler distinguishes."""
+
+    def _controller(self, values, exception_code):
+        controller = MagicMock()
+        controller.async_read_input_registers_with_exception = AsyncMock(return_value=(values, exception_code))
+        controller.async_read_holding_registers_with_exception = AsyncMock(return_value=(values, exception_code))
+        return controller
+
+    @pytest.mark.parametrize("register_type", ["input", "holding"])
+    async def test_a_successful_read_returns_values(self, register_type):
+        controller = self._controller([43605, 1, 2], None)
+
+        if register_type == "holding":
+            values, code = await controller.async_read_holding_registers_with_exception(34502, 3)
+        else:
+            values, code = await controller.async_read_input_registers_with_exception(34502, 3)
+
+        assert values == [43605, 1, 2]
+        assert code is None
+
+    async def test_an_illegal_address_reports_the_code(self):
+        """This is what reading a holding register as 'input' produces."""
+        controller = self._controller(None, MODBUS_ILLEGAL_DATA_ADDRESS)
+
+        values, code = await controller.async_read_input_registers_with_exception(44100, 2)
+
+        assert values is None
+        assert code == MODBUS_ILLEGAL_DATA_ADDRESS
+
+    async def test_a_transport_failure_has_no_code(self):
+        """No code means the read failed rather than being rejected."""
+        controller = self._controller(None, None)
+
+        values, code = await controller.async_read_input_registers_with_exception(34502, 3)
+
+        assert values is None
+        assert code is None

--- a/tests/test_v43_features.py
+++ b/tests/test_v43_features.py
@@ -134,15 +134,16 @@ async def test_read_register_rejects_a_bad_address_without_a_server_error(hass: 
 
     from custom_components.solis_modbus.const import MODBUS_ILLEGAL_DATA_ADDRESS
 
-    controller.async_read_input_registers_with_exception = AsyncMock(
-        return_value=(None, MODBUS_ILLEGAL_DATA_ADDRESS)
-    )
+    controller.async_read_input_registers_with_exception = AsyncMock(return_value=(None, MODBUS_ILLEGAL_DATA_ADDRESS))
     await setup_services(hass, controller)
 
     with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
-            DOMAIN, "solis_read_register",
-            {"address": 44100, "count": 2}, blocking=True, return_response=True,
+            DOMAIN,
+            "solis_read_register",
+            {"address": 44100, "count": 2},
+            blocking=True,
+            return_response=True,
         )
 
     assert "44100" in str(err.value)
@@ -159,8 +160,11 @@ async def test_read_register_still_errors_when_the_read_simply_fails(hass: HomeA
 
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
-            DOMAIN, "solis_read_register",
-            {"address": 33169, "count": 2}, blocking=True, return_response=True,
+            DOMAIN,
+            "solis_read_register",
+            {"address": 33169, "count": 2},
+            blocking=True,
+            return_response=True,
         )
 
 

--- a/tests/test_v43_features.py
+++ b/tests/test_v43_features.py
@@ -85,6 +85,8 @@ def controller():
     c.inverter_config.wattage_chosen = 8000
     c.async_read_input_register = AsyncMock(return_value=[0x0001, 0x86A0])
     c.async_read_holding_register = AsyncMock(return_value=[33])
+    c.async_read_input_registers_with_exception = AsyncMock(return_value=([0x0001, 0x86A0], None))
+    c.async_read_holding_registers_with_exception = AsyncMock(return_value=([33], None))
     c.async_write_holding_register = AsyncMock()
     return c
 
@@ -103,7 +105,7 @@ async def setup_services(hass, controller):
 async def test_read_register_service_returns_values(hass: HomeAssistant, controller):
     await setup_services(hass, controller)
     response = await hass.services.async_call(DOMAIN, "solis_read_register", {"address": 33169, "count": 2}, blocking=True, return_response=True)
-    controller.async_read_input_register.assert_awaited_once_with(33169, 2)
+    controller.async_read_input_registers_with_exception.assert_awaited_once_with(33169, 2)
     assert response["values"] == [1, 0x86A0]
     assert response["hex"] == ["0x0001", "0x86A0"]
     assert response["u32_be"] == 100000
@@ -116,8 +118,50 @@ async def test_read_register_holding(hass: HomeAssistant, controller):
     response = await hass.services.async_call(
         DOMAIN, "solis_read_register", {"address": 43110, "register_type": "holding"}, blocking=True, return_response=True
     )
-    controller.async_read_holding_register.assert_awaited_once_with(43110, 1)
+    controller.async_read_holding_registers_with_exception.assert_awaited_once_with(43110, 1)
     assert response["values"] == [33]
+
+
+@pytest.mark.asyncio
+async def test_read_register_rejects_a_bad_address_without_a_server_error(hass: HomeAssistant, controller):
+    """Probing the wrong register type is a caller mistake, not a crash (#447).
+
+    Reading a holding register as "input" made the inverter reject the address,
+    which surfaced as an unhandled HTTP 500. It should be a validation error
+    naming the other register type instead.
+    """
+    from homeassistant.exceptions import ServiceValidationError
+
+    from custom_components.solis_modbus.const import MODBUS_ILLEGAL_DATA_ADDRESS
+
+    controller.async_read_input_registers_with_exception = AsyncMock(
+        return_value=(None, MODBUS_ILLEGAL_DATA_ADDRESS)
+    )
+    await setup_services(hass, controller)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN, "solis_read_register",
+            {"address": 44100, "count": 2}, blocking=True, return_response=True,
+        )
+
+    assert "44100" in str(err.value)
+    assert "holding" in str(err.value), "should point the user at the other register type"
+
+
+@pytest.mark.asyncio
+async def test_read_register_still_errors_when_the_read_simply_fails(hass: HomeAssistant, controller):
+    """No exception code means a transport failure, which is not the caller's fault."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    controller.async_read_input_registers_with_exception = AsyncMock(return_value=(None, None))
+    await setup_services(hass, controller)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN, "solis_read_register",
+            {"address": 33169, "count": 2}, blocking=True, return_response=True,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### **User description**
Small follow-up from @petervanderwaal1982's Remote Dispatch verification in #447.

Reading the 44100 dispatch block with `register_type: input` returns **HTTP 500**. Those are holding registers, so the inverter rejects the address — a caller mistake while probing, which is entirely routine for a debugging service and shouldn't look like a crash.

## Cause

`async_read_input_register` / `async_read_holding_register` catch the Modbus exception and return `None`, so the handler couldn't distinguish *"you asked for the wrong thing"* from *"the read failed"*. Both became `HomeAssistantError`, which the REST API renders as a 500.

## Fix

Use the existing `*_with_exception` variants, which preserve the Modbus exception code:

- **Illegal data address (code 2)** → `ServiceValidationError`, naming the other register type:
  > The inverter has no input register at 44100 (count 2). If you are probing a documented address, try `register_type: "holding"`.
- **Anything else** → `HomeAssistantError` as before, since that really is a failure.

No change to the success path or the response shape.

## Tests

Updated the two existing service tests to the new call, and added coverage for both outcomes through the real service plus the classification itself. **265 passed.**

Depends on nothing; independent of #448.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Classify rejected register addresses as validation errors

- Suggest probing the alternate register type

- Preserve server errors for genuine read failures

- Add service error-handling regression coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  request["Register read request"]
  detailed["Detailed Modbus read"]
  classify["Classify exception code"]
  validation["Validation error with alternate type"]
  failure["Integration read failure"]
  success["Return register values"]
  request -- "uses exception-aware helper" --> detailed
  detailed -- "values returned" --> success
  detailed -- "read rejected" --> classify
  classify -- "illegal address" --> validation
  classify -- "other failure" --> failure
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Classify rejected register reads as validation errors</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/__init__.py

<ul><li>Uses exception-aware register read helpers<br> <li> Converts illegal addresses into validation errors<br> <li> Recommends trying the alternate register type<br> <li> Retains standard errors for other failures</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/450/files#diff-90c384b3c13c51777899c6bb6f69f01762e31d9fed1da9933a765b6e6fe60be3">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>const.py</strong><dd><code>Define illegal Modbus address exception constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/const.py

<ul><li>Defines the Modbus illegal-address exception code<br> <li> Documents its error-classification purpose</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/450/files#diff-b1b4bf789662b5185f02dfc3e5cf0ff367c5a6e656ea8a9a192116fbdad3539e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_read_register_service.py</strong><dd><code>Add register read outcome classification tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_read_register_service.py

<ul><li>Verifies illegal-address exception classification<br> <li> Covers successful and rejected detailed reads<br> <li> Distinguishes transport failures without exception codes</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/450/files#diff-80cffc872ca43a0861305a4d0146efaafe365bff357db0d11256a6b90f8f3fc5">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_v43_features.py</strong><dd><code>Expand register service error handling coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_v43_features.py

<ul><li>Mocks new exception-aware controller methods<br> <li> Updates successful service read assertions<br> <li> Tests actionable illegal-address validation errors<br> <li> Preserves failures for transport-level read errors</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/450/files#diff-6fa23dab9eb3e6b12ec09dafe8c8388d532837e9340880301279920061a93f3b">+46/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved register-read error handling for unavailable Modbus addresses.
  * Added clearer validation guidance to try the opposite register type when an address is invalid.
  * Preserved existing integration error handling for connection and transport failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->