### PR TITLE
Use BMS-reported limits for battery current settings

### DIFF
--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -2061,7 +2061,6 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 20,
                 "min": 0,
-                "max": 200,
                 "step": 0.1,
             },
             {
@@ -2075,7 +2074,6 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 20,
                 "min": 0,
-                "max": 200,
                 "step": 0.1,
             },
             {"type": "reserve", "register": ["43014", "43015"]},
@@ -3968,7 +3966,6 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 20,
                 "min": 0,
-                "max": 200,
                 "step": 0.1,
             },
             {
@@ -3982,7 +3979,6 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 20,
                 "min": 0,
-                "max": 200,
                 "step": 0.1,
             },
         ],

--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -33,6 +33,26 @@ _LOGGER = logging.getLogger(__name__)
 # unit gives us nothing to derive one from.
 DEFAULT_MAX_VALUE = 3000
 
+# Battery-current setpoints, mapped to the BMS mirror register that publishes the real
+# ceiling for each. The mirrors are what the battery itself reports, so they beat
+# anything derivable from the inverter's rating: an LV bank at 51.2 V or two packs in
+# parallel legitimately sits far above any fixed literal, and an install whose BMS
+# reports less must not be widened past it.
+BATTERY_CURRENT_MIRROR_REGISTERS = {
+    43012: 33206,  # Max Charge Current            <- Battery Max Charge Current Mirror
+    43117: 33206,  # Battery Max Charge Current    <- Battery Max Charge Current Mirror
+    43013: 33207,  # Max Discharge Current         <- Battery Max Discharge Current Mirror
+    43118: 33207,  # Battery Max Discharge Current <- Battery Max Discharge Current Mirror
+}
+
+# The mirrors are U16 on a 0.1 A scale, same as the setpoints they bound.
+BATTERY_CURRENT_MIRROR_MULTIPLIER = 0.1
+
+# Floor for a battery-current setpoint whose ceiling had to be derived: never advertise
+# less than the value that shipped as the literal, so a small rating can't strand an
+# install below what it used to be able to set.
+BATTERY_CURRENT_FLOOR = 200
+
 
 class SolisBaseSensor:
     """Base class for all Solis sensors."""
@@ -129,6 +149,9 @@ class SolisBaseSensor:
         constraints rather than inverter-output constraints — the export limit at
         43074/43291 being the obvious case — so clamping them to the inverter's rated
         wattage caps users below what their grid connection allows (issue #438).
+
+        This only sets the *static* ceiling. Battery-current setpoints prefer the BMS
+        mirror when one has been polled — see the ``max_value`` property.
         """
         if max_default is not None:
             self.max_value = max_default
@@ -147,6 +170,46 @@ class SolisBaseSensor:
         except Exception as e:
             _LOGGER.error("❌ Dynamic UOM set failed, wanted = %s : %s", self.controller.inverter_config.wattage_chosen, e)
             self.max_value = DEFAULT_MAX_VALUE
+
+        if self.battery_current_mirror_register is not None and self._max_value < BATTERY_CURRENT_FLOOR:
+            self._max_value = BATTERY_CURRENT_FLOOR
+
+    @property
+    def battery_current_mirror_register(self) -> int | None:
+        """The BMS mirror register bounding this setpoint, or None if it isn't one."""
+        for reg in self.registrars:
+            mirror = BATTERY_CURRENT_MIRROR_REGISTERS.get(reg)
+            if mirror is not None:
+                return mirror
+        return None
+
+    @property
+    def max_value(self):
+        """The ceiling to advertise, preferring what the BMS reports.
+
+        Resolved live rather than once at construction: the mirrors arrive
+        asynchronously via the poll loop, long after the entity was built.
+        """
+        mirror = self.battery_current_mirror_register
+        if mirror is not None:
+            reported = self._bms_reported_max(mirror)
+            if reported is not None:
+                return reported
+        return self._max_value
+
+    @max_value.setter
+    def max_value(self, value):
+        self._max_value = value
+
+    def _bms_reported_max(self, mirror_register: int) -> float | None:
+        """The mirror's value in amps, or None while it is absent/zero/unreadable."""
+        try:
+            raw = cache_get(self.hass, self.controller, mirror_register)
+        except Exception:  # no cache yet (tests, early setup) — fall back to the static max
+            return None
+        if not isinstance(raw, (int, float)) or isinstance(raw, bool) or raw <= 0:
+            return None
+        return round(raw * BATTERY_CURRENT_MIRROR_MULTIPLIER, 1)
 
     def get_step(self, wanted_step):
         if wanted_step is not None:

--- a/custom_components/solis_modbus/sensors/solis_number_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_number_sensor.py
@@ -52,7 +52,6 @@ class SolisNumberEntity(RestoreNumber, NumberEntity):
         self._attr_native_value = sensor.default
         self._attr_mode = NumberMode.AUTO
         self._attr_native_min_value = sensor.min_value
-        self._attr_native_max_value = sensor.max_value
 
         self._attr_native_step = sensor.step
         self._attr_step = sensor.step
@@ -74,8 +73,39 @@ class SolisNumberEntity(RestoreNumber, NumberEntity):
                     self.handle_modbus_update,
                 )
             )
+
+        # Battery-current setpoints take their ceiling from a BMS mirror register that
+        # this entity doesn't otherwise read; follow it so the advertised max refreshes
+        # when the battery reports a new limit.
+        mirror = getattr(self.base_sensor, "battery_current_mirror_register", None)
+        if isinstance(mirror, int):
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self._hass,
+                    register_update_signal(self.base_sensor.controller, mirror),
+                    self.handle_max_mirror_update,
+                )
+            )
+
         if not self.base_sensor.enabled:
             self._attr_available = False
+
+    @property
+    def native_max_value(self) -> float:
+        """Read the ceiling from the base sensor on every access.
+
+        ``RestoreNumber`` restores the *value*, not the bounds, and the BMS mirrors that
+        bound the battery-current setpoints land long after ``__init__`` — so the max
+        can't be a value frozen at construction.
+        """
+        return self.base_sensor.max_value
+
+    @callback
+    def handle_max_mirror_update(self, data):
+        """The BMS reported a new current limit — re-publish the bounds."""
+        if not is_correct_controller(self.base_sensor.controller, str(data.get(CONTROLLER)), int(data.get(SLAVE))):
+            return
+        self.schedule_update_ha_state()
 
     def adjust_min_max_step(self, min_wanted: float | None, max_wanted: float | None, step_wanted: float | None):
         # float(43016) & equalization(43017) voltages, and rated capacity(43019)

--- a/tests/test_battery_current_max.py
+++ b/tests/test_battery_current_max.py
@@ -1,0 +1,292 @@
+"""Battery-current setpoints must not be hard-capped at 200 A.
+
+The four battery-current numbers (43012/43013 and 43117/43118) declared ``"max": 200``.
+That literal was dead for the entire life of the AMPERE derivation in ``adjust_max`` —
+the derivation overwrote it unconditionally — until the #438 fix made a declared max
+win. 200 A then became the effective ceiling for the first time, and Home Assistant
+started rejecting ``number.set_value`` above it with ``ServiceValidationError``, which
+also aborts any caller batching writes.
+
+200 A is not a protocol limit (U16 at 0.1 A carries 6553.5 A) and not a hardware one: a
+15 kW LV hybrid at 51.2 V needs ~293 A to reach its own nameplate. The battery already
+publishes its real limit on the mirrors 33206/33207, so that is what bounds these now.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.const import UnitOfElectricCurrent, UnitOfPower
+
+from custom_components.solis_modbus.const import DOMAIN, VALUES
+from custom_components.solis_modbus.helpers import cache_save, notify_register_update
+from custom_components.solis_modbus.sensor_data.hybrid_sensors import hybrid_sensors
+from custom_components.solis_modbus.sensors.solis_base_sensor import (
+    BATTERY_CURRENT_FLOOR,
+    SolisBaseSensor,
+)
+from custom_components.solis_modbus.sensors.solis_number_sensor import SolisNumberEntity
+
+CHARGE_REGISTERS = (43012, 43117)
+DISCHARGE_REGISTERS = (43013, 43118)
+BATTERY_CURRENT_REGISTERS = CHARGE_REGISTERS + DISCHARGE_REGISTERS
+
+CHARGE_MIRROR = 33206
+DISCHARGE_MIRROR = 33207
+
+
+class _Hass:
+    """Just enough hass for the register cache."""
+
+    def __init__(self):
+        self.data = {DOMAIN: {VALUES: {}}}
+
+
+def _controller(wattage_chosen=15000):
+    controller = MagicMock()
+    controller.inverter_config.model = "S6-EH3P"
+    controller.inverter_config.features = []
+    controller.inverter_config.wattage_chosen = wattage_chosen
+    controller.connection_id = "test-link"
+    controller.device_id = 1
+    controller.host = "127.0.0.1"
+    return controller
+
+
+def _sensor(hass, controller, register, max_value=None):
+    return SolisBaseSensor(
+        hass=hass,
+        controller=controller,
+        unique_id=f"u{register}",
+        name=f"Register {register}",
+        registrars=[register],
+        write_register=register,
+        multiplier=0.1,
+        unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        editable=True,
+        step=0.1,
+        min_value=0,
+        max_value=max_value,
+    )
+
+
+class TestDefinitions:
+    """The literal is gone from the shipped definitions."""
+
+    @pytest.mark.parametrize("register", BATTERY_CURRENT_REGISTERS)
+    def test_no_declared_max_on_battery_current(self, register):
+        entity = next(e for g in hybrid_sensors for e in g["entities"] if e.get("register") == [str(register)])
+
+        assert "max" not in entity, f"{entity['name']} declares a max; it must be resolved from the BMS mirror"
+
+    @pytest.mark.parametrize("register", BATTERY_CURRENT_REGISTERS)
+    def test_still_editable_with_a_min(self, register):
+        """Removing the max must not have disturbed the rest of the definition."""
+        entity = next(e for g in hybrid_sensors for e in g["entities"] if e.get("register") == [str(register)])
+
+        assert entity["editable"] is True
+        assert entity["min"] == 0
+        assert entity["step"] == 0.1
+
+
+class TestMirrorDerivedMax:
+    def setup_method(self):
+        self.hass = _Hass()
+        self.controller = _controller(wattage_chosen=15000)
+
+    @pytest.mark.parametrize("register", CHARGE_REGISTERS)
+    def test_charge_registers_follow_the_charge_mirror(self, register):
+        cache_save(self.hass, self.controller, CHARGE_MIRROR, 4000)  # 400.0 A
+        sensor = _sensor(self.hass, self.controller, register)
+
+        assert sensor.max_value == 400.0
+
+    @pytest.mark.parametrize("register", DISCHARGE_REGISTERS)
+    def test_discharge_registers_follow_the_discharge_mirror(self, register):
+        cache_save(self.hass, self.controller, DISCHARGE_MIRROR, 3500)  # 350.0 A
+        sensor = _sensor(self.hass, self.controller, register)
+
+        assert sensor.max_value == 350.0
+
+    def test_charge_and_discharge_mirrors_are_not_crossed(self):
+        cache_save(self.hass, self.controller, CHARGE_MIRROR, 4000)
+        cache_save(self.hass, self.controller, DISCHARGE_MIRROR, 1000)
+
+        assert _sensor(self.hass, self.controller, 43012).max_value == 400.0
+        assert _sensor(self.hass, self.controller, 43013).max_value == 100.0
+
+    def test_a_mirror_below_the_floor_is_not_widened(self):
+        """A BMS that reports 150 A means 150 A — the floor must not override it."""
+        cache_save(self.hass, self.controller, CHARGE_MIRROR, 1500)
+        sensor = _sensor(self.hass, self.controller, 43117)
+
+        assert sensor.max_value == 150.0
+
+    def test_the_mirror_is_read_live_not_frozen_at_construction(self):
+        """Mirrors arrive asynchronously, long after the sensor was built."""
+        sensor = _sensor(self.hass, self.controller, 43012)
+        derived = sensor.max_value
+
+        cache_save(self.hass, self.controller, CHARGE_MIRROR, 2930)
+
+        assert derived != 293.0
+        assert sensor.max_value == 293.0
+
+    @pytest.mark.parametrize("absent", [None, 0])
+    def test_an_absent_or_zero_mirror_falls_back(self, absent):
+        """0 is 'not reported yet', not 'this battery accepts no current'."""
+        if absent is not None:
+            cache_save(self.hass, self.controller, CHARGE_MIRROR, absent)
+        sensor = _sensor(self.hass, self.controller, 43012)
+
+        assert sensor.max_value == round((15000 / 44) / 10) * 20
+
+    def test_a_hass_without_a_cache_falls_back(self):
+        """Construction paths that pass hass=None must not explode."""
+        sensor = _sensor(None, self.controller, 43012)
+
+        assert sensor.max_value == round((15000 / 44) / 10) * 20
+
+
+class TestDerivedFallback:
+    """Without a mirror, the inverter-rating derivation applies — floored at 200 A."""
+
+    def setup_method(self):
+        self.hass = _Hass()
+
+    def test_a_15kw_rating_clears_the_reported_293a(self):
+        sensor = _sensor(self.hass, _controller(wattage_chosen=15000), 43117)
+
+        assert sensor.max_value >= 293
+
+    def test_a_small_rating_is_floored(self):
+        """round((3000/44)/10)*20 = 140 — below what 4.1.x allowed; don't regress."""
+        sensor = _sensor(self.hass, _controller(wattage_chosen=3000), 43012)
+
+        assert sensor.max_value == BATTERY_CURRENT_FLOOR
+
+    def test_the_floor_does_not_leak_to_other_current_entities(self):
+        """Only the four battery-current setpoints get the floor."""
+        sensor = _sensor(self.hass, _controller(wattage_chosen=3000), 43102)
+
+        assert sensor.max_value == round((3000 / 44) / 10) * 20
+
+
+class TestIssue438DoesNotRegress:
+    """Declared maxima on grid registers still win over the inverter rating."""
+
+    def setup_method(self):
+        self.hass = _Hass()
+        self.controller = _controller(wattage_chosen=8000)
+
+    @pytest.mark.parametrize(("register", "declared"), [(43074, 20000), (43291, 15000)])
+    def test_export_limits_keep_their_declared_max(self, register, declared):
+        sensor = SolisBaseSensor(
+            hass=self.hass,
+            controller=self.controller,
+            unique_id="u",
+            name="Backflow Power",
+            registrars=[register],
+            write_register=register,
+            multiplier=100,
+            unit_of_measurement=UnitOfPower.WATT,
+            editable=True,
+            max_value=declared,
+        )
+
+        assert sensor.max_value == declared
+
+    def test_a_declared_max_on_a_battery_register_still_loses_to_the_bms(self):
+        """The mirror is the authority for these four, declared or not."""
+        cache_save(self.hass, self.controller, CHARGE_MIRROR, 4000)
+        sensor = _sensor(self.hass, self.controller, 43012, max_value=200)
+
+        assert sensor.max_value == 400.0
+
+
+@pytest.mark.asyncio
+class TestNumberEntityAdvertisesTheLiveMax:
+    async def test_the_entity_reports_the_mirror(self, hass):
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        cache_save(hass, controller, CHARGE_MIRROR, 2930)
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+
+        assert entity.native_max_value == 293.0
+
+    async def test_the_entity_max_tracks_a_later_mirror_update(self, hass):
+        """The reported bound moves without the entity being rebuilt."""
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+
+        cache_save(hass, controller, CHARGE_MIRROR, 2930)
+
+        assert entity.native_max_value == 293.0
+
+    async def test_a_mirror_arriving_republishes_the_bounds(self, hass):
+        """The mirror isn't one of the entity's own registers — it must still wake it."""
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+        entity.hass = hass
+        entity.entity_id = "number.battery_max_charge_current"
+        await entity.async_added_to_hass()
+        entity.schedule_update_ha_state = MagicMock()
+
+        notify_register_update(hass, controller, CHARGE_MIRROR, 2930)
+        await hass.async_block_till_done()
+
+        entity.schedule_update_ha_state.assert_called()
+
+    async def test_another_inverters_mirror_is_ignored(self, hass):
+        """Two inverters on one logger must not rewrite each other's bounds."""
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+        entity.hass = hass
+        entity.entity_id = "number.battery_max_charge_current"
+        await entity.async_added_to_hass()
+        entity.schedule_update_ha_state = MagicMock()
+
+        other = _controller(wattage_chosen=15000)
+        other.host = "10.0.0.9"
+        other.device_id = 1
+        # Same signal (same connection id + slave), payload from a different host.
+        notify_register_update(hass, other, CHARGE_MIRROR, 500)
+        await hass.async_block_till_done()
+
+        entity.schedule_update_ha_state.assert_not_called()
+
+    async def test_a_restored_state_cannot_reinstate_an_old_ceiling(self, hass):
+        """RestoreNumber restores the value; a stale 200 A bound must not come back."""
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        cache_save(hass, controller, CHARGE_MIRROR, 2930)
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+        entity.hass = hass
+        entity.entity_id = "number.battery_max_charge_current"
+        restored = MagicMock()
+        restored.native_value = 100.0
+        restored.native_max_value = 200
+        entity.async_get_last_number_data = AsyncMock(return_value=restored)
+
+        await entity.async_added_to_hass()
+
+        assert entity.native_value == 100.0
+        assert entity.native_max_value == 293.0
+
+    async def test_293a_is_writable_on_a_15kw_lv_hybrid(self, hass):
+        """The reproduction: set_value 293 used to raise before reaching us."""
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        cache_save(hass, controller, CHARGE_MIRROR, 3000)
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+        entity.schedule_update_ha_state = MagicMock()
+
+        assert entity.native_min_value <= 293 <= entity.native_max_value
+
+        entity.set_native_value(293)
+        await hass.async_block_till_done()
+
+        # 0.1 A scale: 293 A on the wire is 2930.
+        controller.async_write_holding_register.assert_called_with(43117, 2930)


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #[issue number] (if applicable)

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Derive battery current limits from BMS mirrors

- Preserve 200 A fallback minimum

- Refresh number bounds on mirror updates

- Test dynamic limits and regression scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  bms["BMS current mirror registers"]
  cache["Modbus register cache"]
  sensor["Dynamic battery current ceiling"]
  number["Home Assistant number entity"]
  bms -- "publishes limits" --> cache
  cache -- "provides live maximum" --> sensor
  sensor -- "updates bounds" --> number
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid_sensors.py</strong><dd><code>Remove fixed battery current setting limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/hybrid_sensors.py

<ul><li>Removes fixed 200 A current ceilings<br> <li> Allows runtime BMS-derived maximum values</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/455/files#diff-540e84e48ae8dd4a164fe7fa970bf88a7375c29588090e2cfe4b8bf7ff16518f">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>solis_base_sensor.py</strong><dd><code>Derive battery current ceilings from BMS mirrors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_base_sensor.py

<ul><li>Maps current setpoints to BMS mirrors<br> <li> Resolves positive mirror values dynamically<br> <li> Retains static fallback with 200 A floor<br> <li> Preserves declared limits for unrelated entities</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/455/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+63/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_number_sensor.py</strong><dd><code>Refresh number bounds when BMS limits change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_number_sensor.py

<ul><li>Exposes live <code>native_max_value</code> from base sensors<br> <li> Subscribes to relevant mirror register updates<br> <li> Republishes bounds only for matching controllers<br> <li> Prevents restored states freezing stale ceilings</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/455/files#diff-12de5d2a79db4982e540517bacb61591ae1560a31897d2b123b51a5be1cd2b24">+31/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_battery_current_max.py</strong><dd><code>Test dynamic battery current maximum behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_battery_current_max.py

<ul><li>Tests all current setpoint and mirror mappings<br> <li> Covers missing, zero, and changing mirrors<br> <li> Verifies fallback floors and export-limit behavior<br> <li> Validates updates, restoration, isolation, and writes</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/455/files#diff-6d3849fb0c90fcebd34eb219d6a7c6c5fabc55029834cf62c276985e70bec485">+292/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Battery charge and discharge current settings now support limits above 200 A when reported by the BMS.
  * Maximum current values update dynamically as the BMS reports new limits.
  * Added safeguards and fallback limits when BMS data is unavailable or invalid.

* **Bug Fixes**
  * Prevented unrelated devices and settings from inheriting battery-specific limits.
  * Improved handling of restored settings and isolated register updates.

* **Tests**
  * Added coverage for dynamic limits, fallback behavior, device isolation, and high-current configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->