### PR TITLE
Fix duplicate entities with stable unique ID migration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,9 +9,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -29,8 +33,14 @@ jobs:
       - name: Run linter
         run: uv run ruff check
 
-      - name: Check formatting
-        run: uv run ruff format --check
+      - name: Format
+        run: uv run ruff format
+
+      - name: Commit formatting fixes
+        uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          commit_message: "style: apply ruff format"
+          file_pattern: "*.py"
 
       - name: Run all tests
         run: uv run pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,12 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      # Write only on trusted pushes so auto-commit can push format fixes.
+      # Pull requests stay read-only.
+      contents: ${{ github.event_name == 'push' && 'write' || 'read' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
+          # Branch ref required for auto-commit on push; PR uses head ref for the PR branch.
           ref: ${{ github.head_ref || github.ref_name }}
+          # Do not persist a write-capable token on pull_request jobs.
+          persist-credentials: ${{ github.event_name == 'push' }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -33,10 +38,16 @@ jobs:
       - name: Run linter
         run: uv run ruff check
 
+      - name: Check formatting
+        if: github.event_name == 'pull_request'
+        run: uv run ruff format --check
+
       - name: Format
+        if: github.event_name == 'push'
         run: uv run ruff format
 
       - name: Commit formatting fixes
+        if: github.event_name == 'push'
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: "style: apply ruff format"

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ dmypy.json
 
 # Ruff
 .ruff_cache/
+/.idea/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Black">
     <option name="sdkName" value="Python 3.11 (solis-modbus)" />

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 Shaun J.V. Nieuwenhuizen (Pho3niX90)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -833,11 +833,7 @@ async def async_migrate_dict_unique_ids(hass: HomeAssistant, entry: ConfigEntry)
         entries = by_platform[platform]
         for unique_key in unique_keys:
             correct_uid = unique_id_generator(controller, unique_key)
-            matches = [
-                e
-                for e in entries
-                if e.unique_id == correct_uid or _broken_dict_unique_id_matches(e.unique_id or "", unique_key)
-            ]
+            matches = [e for e in entries if e.unique_id == correct_uid or _broken_dict_unique_id_matches(e.unique_id or "", unique_key)]
             if not matches:
                 continue
 

--- a/custom_components/solis_modbus/__init__.py
+++ b/custom_components/solis_modbus/__init__.py
@@ -754,6 +754,149 @@ async def async_migrate_to_serial_ids(hass: HomeAssistant, entry: ConfigEntry) -
     return True
 
 
+def _broken_dict_unique_id_matches(unique_id: str, unique_key: str) -> bool:
+    """True when unique_id is a dict-stringified form for this unique key (#452)."""
+    return f"'unique': '{unique_key}'" in unique_id
+
+
+def _entity_sort_key(entry):
+    """Oldest first; UIDs without data_type sort before those that embed it."""
+    created = getattr(entry, "created_at", None)
+    uid = entry.unique_id or ""
+    has_data_type = "'data_type'" in uid
+    return (created is None, created, has_data_type, entry.entity_id)
+
+
+def _iter_sensor_unique_keys(sensors) -> list[str]:
+    keys: list[str] = []
+    for group in sensors:
+        for entity in group.get("entities", []):
+            if entity.get("type") == "reserve":
+                continue
+            uid_key = entity.get("unique")
+            if uid_key:
+                keys.append(uid_key)
+    return keys
+
+
+async def async_migrate_dict_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Rewrite dict-stringified unique_ids to stable keys; restore original entity_ids.
+
+    Issue #452: SolisSensorGroup passed the whole entity dict into unique_id_generator,
+    so definition changes (e.g. data_type=U32 in v4.2.0) created duplicate entities.
+    For duplicates we remove the oldest registry row (frees the original entity_id,
+    recorder history for that id remains) then rename the newest onto that entity_id
+    with the stable unique_id so HA's rename migration carries post-upgrade history.
+    """
+    import homeassistant.helpers.entity_registry as er
+
+    config = {**entry.data, **entry.options}
+    inverter_serial = config.get(CONF_INVERTER_SERIAL)
+    host = config.get("host")
+    identification = config.get("identification")
+
+    from types import SimpleNamespace
+
+    controller = SimpleNamespace()
+    controller.device_serial_number = inverter_serial
+    controller.identification = identification
+    controller.host = host
+
+    inverter_model = config.get("model")
+    if inverter_model is None:
+        old_type = config.get("type", "hybrid")
+        inverter_model = "S6-EH3P" if old_type == "hybrid" else ("WAVESHARE" if old_type == "hybrid-waveshare" else "S6-GR1P")
+
+    inverter_template: InverterConfig | None = next((inv for inv in SOLIS_INVERTERS if inv.model == inverter_model), None)
+    if inverter_template is None:
+        _LOGGER.warning("Dict unique_id migration skipped: unknown model %s", inverter_model)
+        return True
+
+    user_options = inverter_options_from_config(config, inverter_template)
+    inverter_config = inverter_template.clone_with_options(user_options, config.get("connection", "S2_WL_ST"))
+    if inverter_config.type in [InverterType.STRING, InverterType.GRID]:
+        from .sensor_data.string_sensors import string_sensors as sensors
+    else:
+        from .sensor_data.hybrid_sensors import hybrid_sensors as sensors
+
+    unique_keys = _iter_sensor_unique_keys(sensors)
+    ent_reg = er.async_get(hass)
+    platforms = (Platform.SENSOR, Platform.NUMBER)
+
+    # Index this config entry's entities once per platform.
+    by_platform: dict[str, list] = {p: [] for p in platforms}
+    for ent in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if ent.domain in by_platform:
+            by_platform[ent.domain].append(ent)
+
+    for platform in platforms:
+        entries = by_platform[platform]
+        for unique_key in unique_keys:
+            correct_uid = unique_id_generator(controller, unique_key)
+            matches = [
+                e
+                for e in entries
+                if e.unique_id == correct_uid or _broken_dict_unique_id_matches(e.unique_id or "", unique_key)
+            ]
+            if not matches:
+                continue
+
+            # Drop stale refs after removals within this loop
+            matches = [e for e in matches if ent_reg.async_get(e.entity_id) is not None]
+            if not matches:
+                continue
+
+            if len(matches) == 1:
+                sole = matches[0]
+                if sole.unique_id != correct_uid:
+                    try:
+                        _LOGGER.info(
+                            "Migrating dict unique_id for %s -> %s",
+                            sole.entity_id,
+                            correct_uid,
+                        )
+                        ent_reg.async_update_entity(sole.entity_id, new_unique_id=correct_uid)
+                    except ValueError as err:
+                        _LOGGER.error("Dict unique_id migration failed for %s: %s", sole.entity_id, err)
+                continue
+
+            matches_sorted = sorted(matches, key=_entity_sort_key)
+            oldest = matches_sorted[0]
+            newest = matches_sorted[-1]
+            original_entity_id = oldest.entity_id
+            newest_entity_id = newest.entity_id
+
+            # Remove oldest and any middle ghosts to free original entity_id.
+            for ghost in matches_sorted[:-1]:
+                _LOGGER.info(
+                    "Removing duplicate/orphan entity %s (unique_id=%s) to restore %s",
+                    ghost.entity_id,
+                    ghost.unique_id,
+                    original_entity_id,
+                )
+                ent_reg.async_remove(ghost.entity_id)
+
+            try:
+                _LOGGER.info(
+                    "Restoring %s onto original entity_id %s with stable unique_id",
+                    newest_entity_id,
+                    original_entity_id,
+                )
+                update_kwargs = {"new_unique_id": correct_uid}
+                if newest_entity_id != original_entity_id:
+                    update_kwargs["new_entity_id"] = original_entity_id
+                ent_reg.async_update_entity(newest_entity_id, **update_kwargs)
+            except ValueError as err:
+                _LOGGER.error(
+                    "Failed to restore %s -> %s: %s",
+                    newest_entity_id,
+                    original_entity_id,
+                    err,
+                )
+
+    return True
+
+
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
@@ -766,6 +909,10 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             return False
 
         hass.config_entries.async_update_entry(config_entry, version=3)
+
+    if config_entry.version == 3:
+        await async_migrate_dict_unique_ids(hass, config_entry)
+        hass.config_entries.async_update_entry(config_entry, version=4)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True

--- a/custom_components/solis_modbus/config_flow.py
+++ b/custom_components/solis_modbus/config_flow.py
@@ -137,7 +137,7 @@ def clean_identification(iden: str | None) -> str | None:
 class ModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Modbus configuration flow."""
 
-    VERSION = 3
+    VERSION = 4
     MINOR_VERSION = 0
 
     def __init__(self):

--- a/custom_components/solis_modbus/helpers.py
+++ b/custom_components/solis_modbus/helpers.py
@@ -43,9 +43,7 @@ def unique_id_generator(controller, third_value, fourth_value=None):
     dicts are accepted only as a safety net and reduced to their ``unique`` key.
     """
     if isinstance(third_value, dict):
-        _LOGGER.warning(
-            "unique_id_generator received an entity dict; use entity.get('unique') instead"
-        )
+        _LOGGER.warning("unique_id_generator received an entity dict; use entity.get('unique') instead")
         third_value = third_value.get("unique", "reserve")
 
     if fourth_value is None:

--- a/custom_components/solis_modbus/helpers.py
+++ b/custom_components/solis_modbus/helpers.py
@@ -36,7 +36,18 @@ def hex_to_ascii(hex_value):
 
 
 def unique_id_generator(controller, third_value, fourth_value=None):
-    # new method to generate unique id
+    """Build a stable unique id from serial/identification/host + key parts.
+
+    ``third_value`` must be a string key (or register). Passing a full entity
+    definition dict was a historical bug that embedded ``str(dict)`` in the id;
+    dicts are accepted only as a safety net and reduced to their ``unique`` key.
+    """
+    if isinstance(third_value, dict):
+        _LOGGER.warning(
+            "unique_id_generator received an entity dict; use entity.get('unique') instead"
+        )
+        third_value = third_value.get("unique", "reserve")
+
     if fourth_value is None:
         if controller.device_serial_number is not None:
             return f"{DOMAIN}_{controller.device_serial_number}_{third_value}"

--- a/custom_components/solis_modbus/manifest.json
+++ b/custom_components/solis_modbus/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "pymodbus>=3.11.1"
   ],
-  "version": "4.2.0"
+  "version": "4.2.3"
 }

--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -339,7 +339,7 @@ class SolisSensorGroup:
                     default=entity.get("default", 0),
                     multiplier=entity.get("multiplier", 1),
                     data_type=entity.get("data_type", None),
-                    unique_id=unique_id_generator(controller, entity),
+                    unique_id=unique_id_generator(controller, entity.get("unique", "reserve")),
                     poll_speed=definition.get("poll_speed", PollSpeed.NORMAL),
                 ),
                 definition.get("entities", []),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Test session hooks for Windows + pytest-homeassistant socket blocking."""
+
+import pytest
+import pytest_socket
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    """Re-enable sockets after pytest-homeassistant disables them in the same hook."""
+    outcome = yield
+    outcome.get_result()
+    pytest_socket.enable_socket()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    """Ensure sockets are on before the event_loop fixture creates ProactorEventLoop."""
+    pytest_socket.enable_socket()
+    outcome = yield
+    outcome.get_result()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,15 @@
 """Test session hooks for Windows + pytest-homeassistant socket blocking."""
 
+import sys
+
 import pytest
 import pytest_socket
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_setup(item):
-    """Re-enable sockets after pytest-homeassistant disables them in the same hook."""
-    outcome = yield
-    outcome.get_result()
-    pytest_socket.enable_socket()
-
-
-@pytest.hookimpl(hookwrapper=True)
 def pytest_fixture_setup(fixturedef, request):
-    """Ensure sockets are on before the event_loop fixture creates ProactorEventLoop."""
-    pytest_socket.enable_socket()
+    """On Windows, allow sockets while the event_loop fixture creates ProactorEventLoop."""
+    if sys.platform == "win32" and fixturedef.argname == "event_loop":
+        pytest_socket.enable_socket()
     outcome = yield
     outcome.get_result()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -156,7 +156,7 @@ async def test_options_flow_suggestions_use_merged_data_and_options(hass: HomeAs
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="SNOPT1",
-        version=3,
+        version=4,
         data={
             "connection_type": CONN_TYPE_TCP,
             "inverter_serial": "SNOPT1",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -42,7 +42,7 @@ def make_entry(controller):
     entry = MagicMock()
     entry.data = {"host": "1.2.3.4", "inverter_serial": "SN1234567890", "model": "S6-EH1P"}
     entry.options = {}
-    entry.version = 3
+    entry.version = 4
     entry.minor_version = 0
     entry.unique_id = "SN1234567890"
     entry.runtime_data = SolisRuntimeData(controller=controller)

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -72,8 +72,8 @@ async def test_setup_entry(hass: HomeAssistant):
 async def test_setup_entry_missing_serial_raises_error(hass: HomeAssistant):
     """Test setup failure when serial is missing (ConfigEntryError)."""
     # Create an entry WITHOUT a serial number
-    # We set version=3 to SKIP migration and force it to hit async_setup_entry
-    config_entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4", "port": 502, "slave": 1, "model": "S6-EH1P"}, version=3)
+    # We set version=4 to SKIP migration and force it to hit async_setup_entry
+    config_entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4", "port": 502, "slave": 1, "model": "S6-EH1P"}, version=4)
     config_entry.add_to_hass(hass)
 
     # Now this will run async_setup_entry, fail the validation, and raise ConfigEntryError

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -185,9 +185,7 @@ class TestDictUniqueIdMigration:
 
     @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")
     @patch("homeassistant.helpers.entity_registry.async_get")
-    async def test_upgrade_422_to_423_restores_original_removes_location_prefixed_ghost(
-        self, mock_get_reg, mock_entries
-    ):
+    async def test_upgrade_422_to_423_restores_original_removes_location_prefixed_ghost(self, mock_get_reg, mock_entries):
         """4.2.2 → 4.2.3: restore original entity_id; remove location-prefixed duplicate.
 
         After v4.2.0, the pre-dupe (oldest) entity_id is unavailable and a
@@ -235,10 +233,7 @@ class TestDictUniqueIdMigration:
         # Use a key that exists on hybrid maps; number platform shares unique strings.
         key = "solis_modbus_inverter_overcharge_soc"
         old_uid = f"{DOMAIN}_SN123456_{{'name': 'Max Charge SOC', 'unique': '{key}', 'register': ['43010']}}"
-        new_uid = (
-            f"{DOMAIN}_SN123456_"
-            f"{{'name': 'Max Charge SOC', 'unique': '{key}', 'register': ['43010'], 'data_type': 'U32'}}"
-        )
+        new_uid = f"{DOMAIN}_SN123456_{{'name': 'Max Charge SOC', 'unique': '{key}', 'register': ['43010'], 'data_type': 'U32'}}"
         oldest = _make_registry_entry(
             "number.solis_max_charge_soc",
             old_uid,
@@ -287,9 +282,7 @@ class TestDictUniqueIdMigration:
         await async_migrate_dict_unique_ids(self.hass, self.entry)
 
         assert "sensor.kallare_solis_s6_eh1p_backup_load_total_energy" in self.live
-        assert self.live["sensor.kallare_solis_s6_eh1p_backup_load_total_energy"].unique_id == (
-            f"{DOMAIN}_SN123456_{UNIQUE_KEY}"
-        )
+        assert self.live["sensor.kallare_solis_s6_eh1p_backup_load_total_energy"].unique_id == (f"{DOMAIN}_SN123456_{UNIQUE_KEY}")
         # No rename when only one remains
         kwargs = self.registry.async_update_entity.call_args.kwargs
         assert "new_entity_id" not in kwargs

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -157,35 +157,56 @@ class TestDictUniqueIdMigration:
 
     @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")
     @patch("homeassistant.helpers.entity_registry.async_get")
-    async def test_single_broken_rewrites_unique_id_keeps_entity_id(self, mock_get_reg, mock_entries):
-        """4.1.6-style: one dict UID → stable; entity_id unchanged."""
+    async def test_upgrade_416_to_423_rewrites_unique_id_keeps_entity_id(self, mock_get_reg, mock_entries):
+        """4.1.6 → 4.2.3: one entity; rewrite unique_id only; no rename, no duplicates.
+
+        Pre-4.2.0 installs have a single dict-stringified unique_id per sensor.
+        Migration must keep that entity_id so dashboards/automations keep working.
+        """
         mock_get_reg.return_value = self.registry
+        original_entity_id = "sensor.solis_s6_eh1p_backup_load_total_energy"
         broken = _broken_uid("SN123456", with_data_type=False)
-        ent = _make_registry_entry("sensor.solis_s6_eh1p_backup_load_total_energy", broken)
+        ent = _make_registry_entry(original_entity_id, broken)
         self.live[ent.entity_id] = ent
         mock_entries.return_value = [ent]
 
         await async_migrate_dict_unique_ids(self.hass, self.entry)
 
-        assert "sensor.solis_s6_eh1p_backup_load_total_energy" in self.live
-        assert self.live["sensor.solis_s6_eh1p_backup_load_total_energy"].unique_id == (
-            f"{DOMAIN}_SN123456_{UNIQUE_KEY}"
+        assert list(self.live.keys()) == [original_entity_id], "must not create a second entity"
+        survivor = self.live[original_entity_id]
+        assert survivor.entity_id == original_entity_id
+        assert survivor.unique_id == f"{DOMAIN}_SN123456_{UNIQUE_KEY}"
+        self.registry.async_remove.assert_not_called()
+        self.registry.async_update_entity.assert_called_once_with(
+            original_entity_id,
+            new_unique_id=f"{DOMAIN}_SN123456_{UNIQUE_KEY}",
         )
+        assert "new_entity_id" not in self.registry.async_update_entity.call_args.kwargs
 
     @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")
     @patch("homeassistant.helpers.entity_registry.async_get")
-    async def test_duplicate_renames_newest_onto_original(self, mock_get_reg, mock_entries):
-        """4.2.x duplicate: remove oldest, rename newest onto original entity_id."""
+    async def test_upgrade_422_to_423_restores_original_removes_location_prefixed_ghost(
+        self, mock_get_reg, mock_entries
+    ):
+        """4.2.2 → 4.2.3: restore original entity_id; remove location-prefixed duplicate.
+
+        After v4.2.0, the pre-dupe (oldest) entity_id is unavailable and a
+        location-prefixed duplicate holds live values. Migration frees the
+        original entity_id, renames the live row onto it (recorder follows),
+        and leaves exactly one entity with the stable unique_id.
+        """
         mock_get_reg.return_value = self.registry
+        original_entity_id = "sensor.solis_s6_eh1p_backup_load_total_energy"
+        location_prefixed_id = "sensor.kallare_solis_s6_eh1p_backup_load_total_energy"
         old_uid = _broken_uid("SN123456", with_data_type=False)
         new_uid = _broken_uid("SN123456", with_data_type=True)
         oldest = _make_registry_entry(
-            "sensor.solis_s6_eh1p_backup_load_total_energy",
+            original_entity_id,
             old_uid,
             created_at=datetime(2025, 1, 1, tzinfo=UTC),
         )
         newest = _make_registry_entry(
-            "sensor.kallare_solis_s6_eh1p_backup_load_total_energy",
+            location_prefixed_id,
             new_uid,
             created_at=datetime(2026, 8, 1, tzinfo=UTC),
         )
@@ -195,15 +216,16 @@ class TestDictUniqueIdMigration:
 
         await async_migrate_dict_unique_ids(self.hass, self.entry)
 
-        assert "sensor.kallare_solis_s6_eh1p_backup_load_total_energy" not in self.live
-        assert "sensor.solis_s6_eh1p_backup_load_total_energy" in self.live
-        survivor = self.live["sensor.solis_s6_eh1p_backup_load_total_energy"]
+        assert location_prefixed_id not in self.live, "location-prefixed ghost must be gone"
+        assert list(self.live.keys()) == [original_entity_id], "original entity_id must be restored as sole survivor"
+        survivor = self.live[original_entity_id]
+        assert survivor.entity_id == original_entity_id
         assert survivor.unique_id == f"{DOMAIN}_SN123456_{UNIQUE_KEY}"
-        self.registry.async_remove.assert_called_once_with("sensor.solis_s6_eh1p_backup_load_total_energy")
+        self.registry.async_remove.assert_called_once_with(original_entity_id)
         self.registry.async_update_entity.assert_called_once_with(
-            "sensor.kallare_solis_s6_eh1p_backup_load_total_energy",
+            location_prefixed_id,
             new_unique_id=f"{DOMAIN}_SN123456_{UNIQUE_KEY}",
-            new_entity_id="sensor.solis_s6_eh1p_backup_load_total_energy",
+            new_entity_id=original_entity_id,
         )
 
     @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,10 +1,23 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_HOST, CONF_PORT
 
-from custom_components.solis_modbus import async_migrate_entry
+from custom_components.solis_modbus import async_migrate_dict_unique_ids, async_migrate_entry
 from custom_components.solis_modbus.const import CONF_INVERTER_SERIAL, DOMAIN
+from custom_components.solis_modbus.helpers import unique_id_generator
+from custom_components.solis_modbus.sensors.solis_base_sensor import SolisSensorGroup
+
+
+def _apply_version_updates(entry):
+    """Make mocked async_update_entry actually bump entry.version."""
+
+    def _update(config_entry, **kwargs):
+        if "version" in kwargs:
+            config_entry.version = kwargs["version"]
+
+    return _update
 
 
 @pytest.mark.asyncio
@@ -14,20 +27,26 @@ class TestMigration:
         self.entry = MagicMock()
         self.entry.version = 1
         self.entry.domain = DOMAIN
-        self.entry.data = {CONF_HOST: "192.168.1.10", CONF_PORT: 502, "slave": 1, CONF_INVERTER_SERIAL: "SN123456"}
+        self.entry.entry_id = "entry-1"
+        self.entry.data = {CONF_HOST: "192.168.1.10", CONF_PORT: 502, "slave": 1, CONF_INVERTER_SERIAL: "SN123456", "model": "S6-EH1P"}
+        self.entry.options = {}
         self.entry.unique_id = "192.168.1.10_1"
         self.registry = MagicMock()
+        self.dev_registry = MagicMock()
+        self.dev_registry.devices.get_devices_for_config_entry_id.return_value = []
 
-        # Test Data
         self.old_uid = "solis_modbus_192.168.1.10_solis_modbus_inverter_active_power"
         self.new_uid = "solis_modbus_SN123456_solis_modbus_inverter_active_power"
 
+    @patch("homeassistant.helpers.device_registry.async_get")
     @patch("homeassistant.helpers.entity_registry.async_get")
-    async def test_migrate_happy_path(self, mock_get_registry):
-        """Test standard migration: Old exists, New does not."""
+    @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry", return_value=[])
+    async def test_migrate_happy_path(self, _mock_entries, mock_get_registry, mock_get_dev_registry):
+        """Serial migrate then dict migrate: version lands on 4."""
         mock_get_registry.return_value = self.registry
+        mock_get_dev_registry.return_value = self.dev_registry
+        self.hass.config_entries.async_update_entry.side_effect = _apply_version_updates(self.entry)
 
-        # MOCK LOGIC:
         def get_entity_side_effect(platform, domain, unique_id):
             if unique_id == self.old_uid:
                 return "sensor.solis_old_entity"
@@ -37,47 +56,274 @@ class TestMigration:
 
         self.registry.async_get_entity_id.side_effect = get_entity_side_effect
 
-        # Run Migration
         result = await async_migrate_entry(self.hass, self.entry)
 
-        # Verify Success
         assert result is True
+        assert self.entry.version == 4
+        self.hass.config_entries.async_update_entry.assert_any_call(self.entry, version=3)
+        self.hass.config_entries.async_update_entry.assert_any_call(self.entry, version=4)
 
-        # FIX 2: Remove 'data=ANY' (your code only updates the version)
-        self.hass.config_entries.async_update_entry.assert_called_with(self.entry, version=3)
-
+    @patch("homeassistant.helpers.device_registry.async_get")
     @patch("homeassistant.helpers.entity_registry.async_get")
-    async def test_migrate_collision(self, mock_get_registry):
-        """Test collision: Both Old and New IDs exist (Ghost entity)."""
+    @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry", return_value=[])
+    async def test_migrate_collision(self, _mock_entries, mock_get_registry, mock_get_dev_registry):
         mock_get_registry.return_value = self.registry
+        mock_get_dev_registry.return_value = self.dev_registry
+        self.hass.config_entries.async_update_entry.side_effect = _apply_version_updates(self.entry)
 
-        # MOCK LOGIC: Both return an entity ID
         def get_entity_side_effect(platform, domain, unique_id):
             if unique_id == self.old_uid:
-                return "sensor.solis_old_history"  # Keep this
+                return "sensor.solis_old_history"
             if unique_id == self.new_uid:
-                return "sensor.solis_new_ghost"  # Delete this
+                return "sensor.solis_new_ghost"
             return None
 
         self.registry.async_get_entity_id.side_effect = get_entity_side_effect
 
-        # Run Migration
         result = await async_migrate_entry(self.hass, self.entry)
 
         assert result is True
-
-        self.hass.config_entries.async_update_entry.assert_called_with(self.entry, version=3)
+        assert self.entry.version == 4
 
     @patch("homeassistant.helpers.entity_registry.async_get")
     async def test_missing_serial(self, mock_get_registry):
-        """Test missing serial number."""
         mock_get_registry.return_value = self.registry
-
-        # Remove serial from data
         self.entry.data[CONF_INVERTER_SERIAL] = None
 
-        # Run Migration
         result = await async_migrate_entry(self.hass, self.entry)
 
-        # Should be False because migration is deferred when serial is missing
         assert result is False
+
+
+def _make_registry_entry(entity_id, unique_id, domain="sensor", created_at=None):
+    ent = MagicMock()
+    ent.entity_id = entity_id
+    ent.unique_id = unique_id
+    ent.domain = domain
+    ent.created_at = created_at
+    return ent
+
+
+UNIQUE_KEY = "solis_modbus_inverter_backup_total_energy"
+
+
+def _broken_uid(serial: str, with_data_type: bool) -> str:
+    entity = {
+        "name": "Backup Load Total Energy",
+        "unique": UNIQUE_KEY,
+        "register": ["33590", "33591"],
+    }
+    if with_data_type:
+        entity["data_type"] = "U32"
+    return f"{DOMAIN}_{serial}_{entity}"
+
+
+@pytest.mark.asyncio
+class TestDictUniqueIdMigration:
+    def setup_method(self):
+        self.hass = MagicMock()
+        self.entry = MagicMock()
+        self.entry.version = 3
+        self.entry.entry_id = "entry-dict-1"
+        self.entry.data = {
+            CONF_HOST: "192.168.1.10",
+            CONF_PORT: 502,
+            "slave": 1,
+            CONF_INVERTER_SERIAL: "SN123456",
+            "model": "S6-EH1P",
+        }
+        self.entry.options = {}
+        self.registry = MagicMock()
+        self.live = {}
+
+        def async_get(entity_id):
+            return self.live.get(entity_id)
+
+        def async_remove(entity_id):
+            self.live.pop(entity_id, None)
+
+        def async_update_entity(entity_id, **kwargs):
+            ent = self.live.pop(entity_id)
+            if "new_unique_id" in kwargs:
+                ent.unique_id = kwargs["new_unique_id"]
+            new_eid = kwargs.get("new_entity_id", entity_id)
+            ent.entity_id = new_eid
+            self.live[new_eid] = ent
+            return ent
+
+        self.registry.async_get.side_effect = async_get
+        self.registry.async_remove.side_effect = async_remove
+        self.registry.async_update_entity.side_effect = async_update_entity
+
+    @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")
+    @patch("homeassistant.helpers.entity_registry.async_get")
+    async def test_single_broken_rewrites_unique_id_keeps_entity_id(self, mock_get_reg, mock_entries):
+        """4.1.6-style: one dict UID → stable; entity_id unchanged."""
+        mock_get_reg.return_value = self.registry
+        broken = _broken_uid("SN123456", with_data_type=False)
+        ent = _make_registry_entry("sensor.solis_s6_eh1p_backup_load_total_energy", broken)
+        self.live[ent.entity_id] = ent
+        mock_entries.return_value = [ent]
+
+        await async_migrate_dict_unique_ids(self.hass, self.entry)
+
+        assert "sensor.solis_s6_eh1p_backup_load_total_energy" in self.live
+        assert self.live["sensor.solis_s6_eh1p_backup_load_total_energy"].unique_id == (
+            f"{DOMAIN}_SN123456_{UNIQUE_KEY}"
+        )
+
+    @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")
+    @patch("homeassistant.helpers.entity_registry.async_get")
+    async def test_duplicate_renames_newest_onto_original(self, mock_get_reg, mock_entries):
+        """4.2.x duplicate: remove oldest, rename newest onto original entity_id."""
+        mock_get_reg.return_value = self.registry
+        old_uid = _broken_uid("SN123456", with_data_type=False)
+        new_uid = _broken_uid("SN123456", with_data_type=True)
+        oldest = _make_registry_entry(
+            "sensor.solis_s6_eh1p_backup_load_total_energy",
+            old_uid,
+            created_at=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        newest = _make_registry_entry(
+            "sensor.kallare_solis_s6_eh1p_backup_load_total_energy",
+            new_uid,
+            created_at=datetime(2026, 8, 1, tzinfo=UTC),
+        )
+        self.live[oldest.entity_id] = oldest
+        self.live[newest.entity_id] = newest
+        mock_entries.return_value = [oldest, newest]
+
+        await async_migrate_dict_unique_ids(self.hass, self.entry)
+
+        assert "sensor.kallare_solis_s6_eh1p_backup_load_total_energy" not in self.live
+        assert "sensor.solis_s6_eh1p_backup_load_total_energy" in self.live
+        survivor = self.live["sensor.solis_s6_eh1p_backup_load_total_energy"]
+        assert survivor.unique_id == f"{DOMAIN}_SN123456_{UNIQUE_KEY}"
+        self.registry.async_remove.assert_called_once_with("sensor.solis_s6_eh1p_backup_load_total_energy")
+        self.registry.async_update_entity.assert_called_once_with(
+            "sensor.kallare_solis_s6_eh1p_backup_load_total_energy",
+            new_unique_id=f"{DOMAIN}_SN123456_{UNIQUE_KEY}",
+            new_entity_id="sensor.solis_s6_eh1p_backup_load_total_energy",
+        )
+
+    @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")
+    @patch("homeassistant.helpers.entity_registry.async_get")
+    async def test_number_platform_duplicate(self, mock_get_reg, mock_entries):
+        mock_get_reg.return_value = self.registry
+        # Use a key that exists on hybrid maps; number platform shares unique strings.
+        key = "solis_modbus_inverter_overcharge_soc"
+        old_uid = f"{DOMAIN}_SN123456_{{'name': 'Max Charge SOC', 'unique': '{key}', 'register': ['43010']}}"
+        new_uid = (
+            f"{DOMAIN}_SN123456_"
+            f"{{'name': 'Max Charge SOC', 'unique': '{key}', 'register': ['43010'], 'data_type': 'U32'}}"
+        )
+        oldest = _make_registry_entry(
+            "number.solis_max_charge_soc",
+            old_uid,
+            domain="number",
+            created_at=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        newest = _make_registry_entry(
+            "number.kallare_solis_max_charge_soc",
+            new_uid,
+            domain="number",
+            created_at=datetime(2026, 8, 1, tzinfo=UTC),
+        )
+        self.live[oldest.entity_id] = oldest
+        self.live[newest.entity_id] = newest
+        mock_entries.return_value = [oldest, newest]
+
+        await async_migrate_dict_unique_ids(self.hass, self.entry)
+
+        assert "number.solis_max_charge_soc" in self.live
+        assert "number.kallare_solis_max_charge_soc" not in self.live
+        assert self.live["number.solis_max_charge_soc"].unique_id == f"{DOMAIN}_SN123456_{key}"
+
+    @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")
+    @patch("homeassistant.helpers.entity_registry.async_get")
+    async def test_already_correct_noop(self, mock_get_reg, mock_entries):
+        mock_get_reg.return_value = self.registry
+        correct = f"{DOMAIN}_SN123456_{UNIQUE_KEY}"
+        ent = _make_registry_entry("sensor.solis_s6_eh1p_backup_load_total_energy", correct)
+        self.live[ent.entity_id] = ent
+        mock_entries.return_value = [ent]
+
+        await async_migrate_dict_unique_ids(self.hass, self.entry)
+
+        self.registry.async_update_entity.assert_not_called()
+        self.registry.async_remove.assert_not_called()
+
+    @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry")
+    @patch("homeassistant.helpers.entity_registry.async_get")
+    async def test_only_newest_left_rewrites_in_place(self, mock_get_reg, mock_entries):
+        mock_get_reg.return_value = self.registry
+        new_uid = _broken_uid("SN123456", with_data_type=True)
+        ent = _make_registry_entry("sensor.kallare_solis_s6_eh1p_backup_load_total_energy", new_uid)
+        self.live[ent.entity_id] = ent
+        mock_entries.return_value = [ent]
+
+        await async_migrate_dict_unique_ids(self.hass, self.entry)
+
+        assert "sensor.kallare_solis_s6_eh1p_backup_load_total_energy" in self.live
+        assert self.live["sensor.kallare_solis_s6_eh1p_backup_load_total_energy"].unique_id == (
+            f"{DOMAIN}_SN123456_{UNIQUE_KEY}"
+        )
+        # No rename when only one remains
+        kwargs = self.registry.async_update_entity.call_args.kwargs
+        assert "new_entity_id" not in kwargs
+
+    @patch("homeassistant.helpers.entity_registry.async_entries_for_config_entry", return_value=[])
+    @patch("homeassistant.helpers.entity_registry.async_get")
+    async def test_version_3_to_4_runs_dict_migration(self, mock_get_reg, _mock_entries):
+        mock_get_reg.return_value = self.registry
+        self.hass.config_entries.async_update_entry.side_effect = _apply_version_updates(self.entry)
+
+        result = await async_migrate_entry(self.hass, self.entry)
+
+        assert result is True
+        assert self.entry.version == 4
+
+
+class TestUniqueIdCallSite:
+    def test_dict_guard_extracts_unique_key(self):
+        controller = MagicMock()
+        controller.device_serial_number = "SN1"
+        controller.identification = None
+        controller.host = "1.2.3.4"
+        entity = {"name": "X", "unique": "solis_modbus_inverter_backup_total_energy"}
+        assert unique_id_generator(controller, entity) == f"{DOMAIN}_SN1_solis_modbus_inverter_backup_total_energy"
+
+    def test_sensor_group_uses_unique_key_not_dict_str(self):
+        hass = MagicMock()
+        controller = MagicMock()
+        controller.device_serial_number = "SN1"
+        controller.identification = None
+        controller.host = "1.2.3.4"
+        controller.inverter_config = MagicMock()
+        controller.inverter_config.model = "S6-EH1P"
+        controller.inverter_config.features = set()
+        controller.inverter_config.wattage_chosen = 6000
+
+        definition = {
+            "register_start": 33590,
+            "poll_speed": MagicMock(),
+            "entities": [
+                {
+                    "name": "Backup Load Total Energy",
+                    "unique": UNIQUE_KEY,
+                    "register": ["33590", "33591"],
+                    "data_type": "U32",
+                }
+            ],
+        }
+        # Avoid PollSpeed enum comparison issues in start_register path
+        from custom_components.solis_modbus.data.enums import PollSpeed
+
+        definition["poll_speed"] = PollSpeed.SLOW
+
+        group = SolisSensorGroup(hass=hass, definition=definition, controller=controller)
+        assert len(group.sensors) == 1
+        uid = group.sensors[0].unique_id
+        assert uid == f"{DOMAIN}_SN1_{UNIQUE_KEY}"
+        assert "{" not in uid
+        assert "data_type" not in uid

--- a/tests/test_unique_id_generator.py
+++ b/tests/test_unique_id_generator.py
@@ -50,6 +50,28 @@ class TestUniqueIdGenerator(unittest.TestCase):
         expected_id = f"{DOMAIN}_SN123456_test_sensor"
         self.assertEqual(unique_id, expected_id, "Serial Number should take precedence over Identification")
 
+    def test_dict_argument_extracts_unique_key(self):
+        """#452 safety net: dict args must not stringify the whole definition."""
+        self.controller.device_serial_number = "SN123456"
+        entity = {
+            "name": "Backup Load Total Energy",
+            "unique": "solis_modbus_inverter_backup_total_energy",
+            "register": ["33590", "33591"],
+            "data_type": "U32",
+        }
+        unique_id = unique_id_generator(self.controller, entity)
+        self.assertEqual(unique_id, f"{DOMAIN}_SN123456_solis_modbus_inverter_backup_total_energy")
+        self.assertNotIn("{", unique_id)
+        self.assertNotIn("data_type", unique_id)
+
+    def test_dict_argument_stable_when_keys_added(self):
+        """Adding definition keys must not change the generated unique_id."""
+        self.controller.device_serial_number = "SN123456"
+        key = "solis_modbus_inverter_backup_total_energy"
+        before = unique_id_generator(self.controller, {"unique": key})
+        after = unique_id_generator(self.controller, {"unique": key, "data_type": "U32", "category": "LOAD"})
+        self.assertEqual(before, after)
+
 
 class TestRegisterCacheKey(unittest.TestCase):
     def test_parallel_slaves_distinct(self):

--- a/tests/test_unique_id_stability.py
+++ b/tests/test_unique_id_stability.py
@@ -1,0 +1,141 @@
+"""Regression guards for issue #452 — unique_id must not embed entity definition dicts.
+
+v4.2.0 created duplicate entities because SolisSensorGroup passed the whole entity
+dict into unique_id_generator, so unique IDs became ``..._{str(dict)}``. Adding
+``data_type: U32`` (or any other key) then changed the unique_id and HA registered
+a second entity.
+
+These tests fail if that call-site or stringification pattern returns.
+"""
+
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solis_modbus.const import DOMAIN
+from custom_components.solis_modbus.data.enums import DataType, PollSpeed
+from custom_components.solis_modbus.helpers import unique_id_generator
+from custom_components.solis_modbus.sensor_data.hybrid_sensors import hybrid_sensors
+from custom_components.solis_modbus.sensor_data.string_sensors import string_sensors
+from custom_components.solis_modbus.sensors.solis_base_sensor import SolisSensorGroup
+
+
+def _controller(serial="SN_REGRESSION"):
+    controller = MagicMock()
+    controller.device_serial_number = serial
+    controller.identification = None
+    controller.host = "10.0.0.1"
+    controller.inverter_config = MagicMock()
+    controller.inverter_config.model = "S6-EH3P"
+    controller.inverter_config.features = set()
+    controller.inverter_config.wattage_chosen = 10000
+    return controller
+
+
+def _build_group(controller, group):
+    definition = deepcopy(group)
+    definition.setdefault("poll_speed", PollSpeed.NORMAL)
+    return SolisSensorGroup(hass=MagicMock(), definition=definition, controller=controller)
+
+
+def test_adding_data_type_does_not_change_unique_id():
+    """Exact #452 shape: tagging a lifetime total as U32 must not mint a new unique_id."""
+    controller = _controller()
+    base_entity = {
+        "name": "Backup Load Total Energy",
+        "unique": "solis_modbus_inverter_backup_total_energy",
+        "register": ["33590", "33591"],
+        "multiplier": 0,
+    }
+    with_u32 = {**base_entity, "data_type": DataType.U32}
+
+    group_before = _build_group(
+        controller,
+        {"register_start": 33590, "poll_speed": PollSpeed.SLOW, "entities": [base_entity]},
+    )
+    group_after = _build_group(
+        controller,
+        {"register_start": 33590, "poll_speed": PollSpeed.SLOW, "entities": [with_u32]},
+    )
+
+    uid_before = group_before.sensors[0].unique_id
+    uid_after = group_after.sensors[0].unique_id
+    expected = f"{DOMAIN}_SN_REGRESSION_solis_modbus_inverter_backup_total_energy"
+
+    assert uid_before == expected
+    assert uid_after == expected
+    assert uid_before == uid_after
+    assert "{" not in uid_before
+    assert "data_type" not in uid_after
+
+
+def test_arbitrary_definition_keys_do_not_change_unique_id():
+    """Any future definition field must leave unique_id keyed only on ``unique``."""
+    controller = _controller()
+    unique_key = "solis_modbus_inverter_pv_total_generation"
+    minimal = {
+        "name": "PV Total Energy Generation",
+        "unique": unique_key,
+        "register": ["33029", "33030"],
+    }
+    bloated = {
+        **minimal,
+        "category": "PV_INFORMATION",
+        "data_type": DataType.U32,
+        "device_class": "energy",
+        "state_class": "total_increasing",
+        "multiplier": 0,
+        "hidden": False,
+        "enabled": True,
+        "_future_flag": True,
+    }
+
+    a = _build_group(controller, {"register_start": 33029, "entities": [minimal]}).sensors[0].unique_id
+    b = _build_group(controller, {"register_start": 33029, "entities": [bloated]}).sensors[0].unique_id
+    assert a == b == f"{DOMAIN}_SN_REGRESSION_{unique_key}"
+
+
+@pytest.mark.parametrize(
+    "name,groups",
+    [
+        ("hybrid", hybrid_sensors),
+        ("string", string_sensors),
+    ],
+)
+def test_all_sensor_group_unique_ids_are_stable_format(name, groups):
+    """Every SolisSensorGroup entity unique_id must be DOMAIN_serial_<unique key>.
+
+    Catches a return of ``unique_id_generator(controller, entity)`` with the whole
+    dict: those IDs contain ``{`` / ``'unique':``.
+    """
+    controller = _controller(serial="SN_MATRIX")
+    offenders = []
+
+    for group in groups:
+        built = _build_group(controller, group)
+        for entity_def, sensor in zip(group.get("entities", []), built.sensors, strict=False):
+            if entity_def.get("type") == "reserve":
+                continue
+            unique_key = entity_def.get("unique", "reserve")
+            expected = unique_id_generator(controller, unique_key)
+            uid = sensor.unique_id
+            if uid != expected:
+                offenders.append(f"{name}:{unique_key}: got {uid!r} expected {expected!r}")
+            if "{" in uid or "'unique':" in uid or "data_type" in uid:
+                offenders.append(f"{name}:{unique_key}: looks dict-stringified: {uid!r}")
+
+    assert not offenders, "unstable unique_ids (#452 regression):\n  " + "\n  ".join(offenders[:20])
+
+
+def test_unique_id_generator_dict_guard_ignores_extra_keys():
+    """Safety net: even if a caller passes a dict, only ``unique`` is used."""
+    controller = _controller(serial="SN_GUARD")
+    key = "solis_modbus_inverter_total_battery_charge_energy"
+    plain = unique_id_generator(controller, {"unique": key, "name": "A"})
+    with_extra = unique_id_generator(
+        controller,
+        {"unique": key, "name": "A", "data_type": DataType.U32, "register": ["33161", "33162"]},
+    )
+    assert plain == with_extra == f"{DOMAIN}_SN_GUARD_{key}"
+    assert "{" not in plain


### PR DESCRIPTION
### **User description**
- feat: ensure unique_id stability and resolve #452 regressions
- Add tests to validate unique_id stability to prevent dict stringification (#452).
- Refactor `unique_id_generator` to ensure only `unique` key impacts unique_id.
- Implement migration logic to fix dict-strung unique_ids from prior versions.
- Update configuration flow and tests to version 4 for migration support.
- Introduce helper functions and utilities for unique_id migration and cleanup.
- Update manifest to version 4.2.3.

## 🔄 Related Issues
Closes #452

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Any extra details about the PR.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Stabilize entity IDs using unique keys

- Restore duplicates onto original entity IDs

- Add migration and regression test coverage

- Bump integration version to `4.2.3`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  definitions["Entity definitions"]
  stableIDs["Stable unique-key IDs"]
  migration["Version 4 migration"]
  registry["Restored entity registry"]
  definitions -- "generate IDs" --> stableIDs
  stableIDs -- "identify broken duplicates" --> migration
  migration -- "remove ghosts and preserve names" --> registry
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Migrate duplicate entities to stable identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-90c384b3c13c51777899c6bb6f69f01762e31d9fed1da9933a765b6e6fe60be3">+147/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.py</strong><dd><code>Generate stable IDs from unique keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-62575804e6e6479bc99910af8f216c62e76af4bc818fc0a93b80c8726b6b65be">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>solis_base_sensor.py</strong><dd><code>Pass sensor unique keys into ID generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>config_flow.py</strong><dd><code>Advance configuration schema to version four</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-2e983e3a2a647135a82c37e4ee143bab14008b7fa1c13da9da8dea903c2e14c3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifest.json</strong><dd><code>Bump integration release version to 4.2.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-cd118a6e8c28d762686f925f1dcd17c9f7075b8c31548d08c7af2120cefb5753">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>conftest.py</strong><dd><code>Enable sockets around Home Assistant test hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_config_flow.py</strong><dd><code>Update configuration flow fixture version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_diagnostics.py</strong><dd><code>Update diagnostics fixture migration version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-cce28077bba940e579c5d82650c804358efaafef732856ccab3a41fbc3a25228">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_integration_setup.py</strong><dd><code>Skip migrations using version four fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-dd719eeb928a67671accb1167b241118f855250bd13e469283dd171626c17715">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_migration.py</strong><dd><code>Cover duplicate cleanup and identifier restoration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-7afc98d2fc1944d3ffc2d6d7b5fb3cea6b97efadb82e67da0670c6cab2cdcf5d">+270/-24</a></td>

</tr>

<tr>
  <td><strong>test_unique_id_generator.py</strong><dd><code>Verify dictionary inputs preserve stable identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-003df7169e6ca659d01cd3512a7da76d8bdf35c9e1f32d5794b98bd611a1176b">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_unique_id_stability.py</strong><dd><code>Add comprehensive unique ID regression guards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-7af66ecb2fa6a345421ad9e3e7f7fe90b3d27bb9b6db415ba6a595156ba9cd86">+141/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>misc.xml</strong><dd><code>Remove redundant XML declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/456/files#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity identification to keep sensor IDs stable when configuration details change.
  * Added automatic migration for existing entities with outdated or duplicate IDs while preserving entity assignments where possible.
  * Improved handling of malformed entity identifiers.

* **Chores**
  * Updated the Solis Modbus integration to version 4.2.3.
  * Added JetBrains project files to ignored development files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->