### PR TITLE
Use static protocol bounds with advisory device limits

### DIFF
--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -2069,9 +2069,10 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 20,
                 "min": 0,
-                # No "max": the ceiling comes from the BMS mirror (33206), falling back to
-                # the inverter rating. A literal here caps LV/multi-pack banks below their
-                # own rated current.
+                # No "max": protocol ceiling. A literal here caps LV/multi-pack banks below
+                # their own rated current, and the BMS mirror (33206) is advisory only —
+                # it derates with SOC (#467) and can echo the setpoint back (#464), so it
+                # is surfaced as the device_limit attribute, never as the bound.
                 "step": 0.1,
             },
             {
@@ -2085,7 +2086,7 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 20,
                 "min": 0,
-                # No "max": bounded by the BMS mirror (33207) — see 43012.
+                # No "max": protocol ceiling; BMS mirror (33207) advisory — see 43012.
                 "step": 0.1,
             },
             {"type": "reserve", "register": ["43014", "43015"]},
@@ -2212,7 +2213,8 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 3000.0,
                 "min": 0,
-                # Force-charge draws through the inverter, so its output rating governs.
+                # Force-charge draws through the inverter, so its output rating is the
+                # advisory device_limit; the bound itself is the protocol ceiling.
                 "max_source": "inverter_rating",
             },
             {
@@ -2290,10 +2292,15 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "data_type": DataType.S16,
-                # Bounded by the inverter's own AC output, not a literal: the shipped
-                # ±10000 was an unsourced round number and capped a 20 kW SKU at half its
-                # rating (#351). The negative min marks this symmetric, so the floor
-                # follows the derived ceiling; the literal is only the unresolved fallback.
+                # No "max": protocol ceiling. The shipped ±10000 literal was an unsourced
+                # round number that capped a 20 kW SKU at half its rating (#351); the
+                # inverter's AC rating is advisory (device_limit), not a bound — HA would
+                # reject dispatch writes above a wrong-low rating (#464/#467 pattern).
+                # The negative min marks this writable below zero; the floor resolves to
+                # the protocol floor, same rule as the ceiling in the opposite direction.
+                # The -10000 value itself is never the bound — only its sign is read
+                # (an undeclared min defaults to 0, so a negative literal is the only
+                # way to say "signed" without hard-coding derivable protocol math).
                 "min": -10000,
                 "max_source": "inverter_rating",
                 "default": 0,
@@ -2310,8 +2317,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # Battery discharge power is bounded by the inverter's AC output. The
-                # shipped 6000 was unsourced and capped a 20 kW SKU (#351).
+                # No "max": protocol ceiling. The shipped 6000 literal was unsourced and
+                # capped a 20 kW SKU (#351); the inverter's AC rating is advisory
+                # (device_limit) — see 43128.
                 "max_source": "inverter_rating",
                 "default": 1500,
                 "register": ["43129"],
@@ -2326,7 +2334,7 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # Bounded by the inverter's AC output — see 43129.
+                # No "max": protocol ceiling; inverter rating advisory — see 43128.
                 "max_source": "inverter_rating",
                 "default": 1500,
                 "register": ["43130"],
@@ -2341,7 +2349,7 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # Bounded by the inverter's AC output — see 43129.
+                # No "max": protocol ceiling; inverter rating advisory — see 43128.
                 "max_source": "inverter_rating",
                 "default": 1500,
                 "register": ["43131"],
@@ -2365,7 +2373,7 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "data_type": DataType.S16,
-                # Symmetric grid-dispatch setpoint bounded by the inverter — see 43128.
+                # Symmetric grid-dispatch setpoint; inverter rating advisory — see 43128.
                 "min": -10000,
                 "max_source": "inverter_rating",
                 "default": 0,
@@ -2382,8 +2390,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "data_type": DataType.S16,
-                # Reactive power, bounded by the apparent-power rating we hold for the
-                # inverter — approximate, but far closer than the unsourced ±10000.
+                # Reactive power: the apparent-power rating we hold for the inverter is
+                # the advisory device_limit (approximate, but sourced, unlike the old
+                # ±10000 literal); the bound itself is the protocol ceiling — see 43128.
                 "min": -10000,
                 "max_source": "inverter_rating",
                 "default": 0,
@@ -2409,8 +2418,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # The register #351 was filed against: 10000 stopped an S6-EH3P20K owner
-                # force-charging above half their rating.
+                # The register #351 was filed against: a 10000 literal stopped an
+                # S6-EH3P20K owner force-charging above half their rating. Rating is
+                # advisory (device_limit); the bound is the protocol ceiling — see 43128.
                 "max_source": "inverter_rating",
                 "default": 1500,
                 "register": ["43136"],
@@ -2448,8 +2458,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror (33206). The old 135 A sat below the
-                # ~293 A a 15 kW LV bank draws at its own nameplate.
+                # No "max": protocol ceiling; BMS mirror (33206) advisory — see 43012. The
+                # old 135 A literal sat below the ~293 A a 15 kW LV bank draws at its own
+                # nameplate.
                 "step": 0.1,
                 "default": 50,
             },
@@ -2464,7 +2475,7 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror (33207) — see 43141.
+                # No "max": protocol ceiling; BMS mirror (33207) advisory — see 43012.
                 "step": 0.1,
                 "default": 50,
             },
@@ -2975,8 +2986,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3055,8 +3067,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3135,8 +3148,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3215,8 +3229,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3295,8 +3310,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3375,8 +3391,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3461,8 +3478,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3541,8 +3559,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3621,8 +3640,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3701,8 +3721,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3781,8 +3802,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3861,8 +3883,9 @@ hybrid_sensors = [
                 "state_class": SensorStateClass.MEASUREMENT,
                 "editable": True,
                 "min": 0,
-                # No "max": bounded by the BMS mirror, like every other battery-current
-                # setpoint. 300 A is under the 580 A a parallel pair reports (#351).
+                # No "max": protocol ceiling, like every other battery-current setpoint;
+                # the BMS mirror is an advisory device_limit attribute, not a bound
+                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -4087,7 +4110,7 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 20,
                 "min": 0,
-                # No "max": bounded by the BMS mirror (33206) — see 43012.
+                # No "max": protocol ceiling; BMS mirror (33206) advisory — see 43012.
                 "step": 0.1,
             },
             {
@@ -4101,7 +4124,7 @@ hybrid_sensors = [
                 "editable": True,
                 "default": 20,
                 "min": 0,
-                # No "max": bounded by the BMS mirror (33207) — see 43012.
+                # No "max": protocol ceiling; BMS mirror (33207) advisory — see 43012.
                 "step": 0.1,
             },
         ],

--- a/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
+++ b/custom_components/solis_modbus/sensor_data/hybrid_sensors.py
@@ -2988,7 +2988,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3069,7 +3070,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3150,7 +3152,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3231,7 +3234,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3312,7 +3316,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3393,7 +3398,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3480,7 +3486,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3561,7 +3568,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3642,7 +3650,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3723,7 +3732,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3804,7 +3814,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {
@@ -3885,7 +3896,8 @@ hybrid_sensors = [
                 "min": 0,
                 # No "max": protocol ceiling, like every other battery-current setpoint;
                 # the BMS mirror is an advisory device_limit attribute, not a bound
-                # (#464/#467). 300 A is under the 580 A a parallel pair reports (#351).
+                # (#464/#467). The removed 300 A literal sat under the 580 A a
+                # parallel pair reports (#351).
                 "step": 0.1,
             },
             {

--- a/custom_components/solis_modbus/sensors/solis_base_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_base_sensor.py
@@ -43,22 +43,32 @@ DATA_TYPE_RAW_RANGES = {
     DataType.S32_LE.value: (-2147483648, 2147483647),
 }
 
-# Definitions opt into the inverter's rated output with "max_source": "inverter_rating".
-# Only for registers the AC rating genuinely governs — the remote-control dispatch and
-# battery-power setpoints. Never for grid-side registers (#438) and never inferred from
-# the unit, which is what made the old derivation retarget registers it never considered.
+# Definitions tag the limit the inverter's rated output governs with
+# "max_source": "inverter_rating" — the remote-control dispatch and battery-power
+# setpoints. The rating is surfaced as an advisory ``device_limit``, never as the
+# advertised max: HA rejects service calls above the advertised max, so a wrong-low
+# rating (misconfigured model, DC-side charging above the AC nameplate) would turn
+# into hard write failures — the same failure mode as #464/#467 on the BMS mirrors.
+# Never applied to grid-side registers (#438) and never inferred from the unit, which
+# is what made the old derivation retarget registers it never considered.
 MAX_SOURCE_INVERTER_RATING = "inverter_rating"
 
-# Battery-current setpoints, mapped to the BMS mirror register that publishes the real
-# ceiling for each. The mirrors are what the battery itself reports, so they beat
-# anything derivable from the inverter's rating: an LV bank at 51.2 V or two packs in
-# parallel legitimately sits far above any fixed literal, and an install whose BMS
-# reports less must not be widened past it.
+# Battery-current setpoints, mapped to the BMS mirror register that publishes the
+# battery's own current limit. The mirrors are surfaced as an advisory ``device_limit``
+# (entity attribute + warning on write), NOT as the advertised max. Two field reports
+# disqualified them as bounds on what may be *configured*:
 #
-# The TOU slot and time-charging currents belong here for the same reason the four
-# originals do (#455): a per-slot charge current cannot sensibly exceed what the battery
-# accepts, and their old literals (135 A / 300 A) sat below both a 15 kW LV bank's ~293 A
-# and the 580 A a parallel pair reports (#351).
+#   #467 — a real BMS (Dyness HV) derates the limit with SOC, so it moves through the
+#          day: the number's state ended up above its own max, TOU slots (scheduled
+#          config) were bounded by the instant the page was opened, and automation
+#          writes intermittently raised out_of_range.
+#   #464 — some firmware echoes the effective setpoint back on the mirror, so lowering
+#          the setpoint lowered the advertised max: a one-way ratchet (users stuck at
+#          1-2 A until they went through Solis Cloud).
+#
+# The TOU slot and time-charging currents are mapped for the same reason the four
+# originals are (#455): their old literals (135 A / 300 A) sat below both a 15 kW LV
+# bank's ~293 A and the 580 A a parallel pair reports (#351).
 BATTERY_CURRENT_MIRROR_REGISTERS = {
     # --- charge -> Battery Max Charge Current Mirror ---
     43012: 33206,  # Max Charge Current
@@ -162,10 +172,11 @@ class SolisBaseSensor:
         self.unit_of_measurement = unit_of_measurement
         self.hidden = hidden
         self.state_class = state_class
-        # min before max: a derived ceiling on a signed register mirrors itself onto the
-        # floor, so adjust_max needs the declared min already in place.
+        # min before max: adjust_max also resolves the floor of a signed register
+        # (marked by a negative declared min), so it needs the min already in place.
         self.min_value = min_value
-        self.adjust_max(max_value, max_source)
+        self.max_source = max_source
+        self.adjust_max(max_value)
         self.step = self.get_step(step)
         self.enabled = enabled
         self.poll_speed = poll_speed
@@ -201,44 +212,34 @@ class SolisBaseSensor:
             if _any_in(self.registrars, s6_registers):
                 self.multiplier = 0.01
 
-    def adjust_max(self, max_default, max_source=None):
-        """Resolve the static ceiling by authority, never by guessing from the unit.
+    def adjust_max(self, max_default):
+        """Resolve the static ceiling: a declared ``"max"``, else the protocol ceiling.
 
-        In order:
+        The advertised bound answers "what may be configured", so it is static and
+        never below what the register can carry:
 
         1. A declared ``"max"`` — a real protocol or datasheet constraint, audited.
-        2. ``"max_source": "inverter_rating"`` — the inverter's rated output, for the
-           registers it genuinely governs. Opted into per register: inferring it from the
-           unit is what capped the export limit at 43074 to the AC rating (#438), and
-           what put a 44 V battery bus behind every ampere setpoint (#455).
-        3. The protocol ceiling — what the register can physically carry.
+        2. The protocol ceiling — what the register can physically carry.
 
-        Rank 0 sits above all of these but is resolved live rather than here: a
-        battery-current setpoint prefers its BMS mirror once polled, see ``max_value``.
+        Live limits — the BMS mirror, the inverter's rated output — are deliberately
+        NOT in this chain. HA rejects ``number.set_value`` above the advertised max, so
+        a moving or wrong-low limit turns into hard write failures and out-of-range
+        states (#464, #467). They are advisory instead: see ``device_limit``.
         """
         if max_default is not None:
             self.max_value = max_default
             return
 
-        derived = None
-        if max_source == MAX_SOURCE_INVERTER_RATING:
-            derived = self._inverter_rating_max()
-
-        if derived is None:
-            derived = self.protocol_max
-
+        derived = self.protocol_max
         self.max_value = derived
-        _LOGGER.debug(
-            "max for %s resolved to %s (no declared max; source=%s)",
-            self.registrars,
-            derived,
-            max_source or "protocol",
-        )
+        _LOGGER.debug("max for %s resolved to protocol ceiling %s (no declared max)", self.registrars, derived)
 
-        # A signed dispatch register is symmetric about zero: raising only the ceiling
-        # would leave 43128/43133/43134 able to import further than they can export.
+        # A negative declared min marks a signed dispatch register (43128/43133/43134)
+        # as writable below zero; the floor then resolves by the same rule as the
+        # ceiling — what the register can physically carry — in the opposite direction.
+        # (A definition declaring its "max" keeps its declared min untouched above.)
         if self.min_value is not None and self.min_value < 0:
-            self.min_value = -derived
+            self.min_value = self.protocol_min
 
     def _inverter_rating_max(self) -> float | None:
         """The inverter's rated output in this entity's unit, or None if unusable."""
@@ -266,8 +267,13 @@ class SolisBaseSensor:
         return self.protocol_raw_range[1] * (self.multiplier or 1)
 
     @property
+    def protocol_min(self) -> float:
+        """The smallest value this register can physically hold, in its own unit."""
+        return self.protocol_raw_range[0] * (self.multiplier or 1)
+
+    @property
     def battery_current_mirror_register(self) -> int | None:
-        """The BMS mirror register bounding this setpoint, or None if it isn't one."""
+        """The BMS mirror register advising this setpoint, or None if it isn't one."""
         for reg in self.registrars:
             mirror = BATTERY_CURRENT_MIRROR_REGISTERS.get(reg)
             if mirror is not None:
@@ -275,28 +281,37 @@ class SolisBaseSensor:
         return None
 
     @property
-    def max_value(self):
-        """The ceiling to advertise, preferring what the BMS reports.
+    def device_limit(self) -> float | None:
+        """What the governing device reports it can do right now, or None.
 
-        Resolved live rather than once at construction: the mirrors arrive
-        asynchronously via the poll loop, long after the entity was built.
+        Advisory only: surfaced as an entity attribute and checked on write for a log
+        warning, never advertised as the number's max. The BMS mirror derates with SOC
+        through the day (#467) and on some firmware echoes the setpoint back (#464);
+        the inverter rating can sit below a legitimate DC-side setpoint — all of which
+        disqualify them as bounds on what may be *configured*. The device enforces its
+        real limit itself at runtime.
         """
         mirror = self.battery_current_mirror_register
         if mirror is not None:
-            reported = self._bms_reported_max(mirror)
-            if reported is not None:
-                return reported
-        return self._max_value
+            return self._bms_reported_max(mirror)
+        if self.max_source == MAX_SOURCE_INVERTER_RATING:
+            return self._inverter_rating_max()
+        return None
 
-    @max_value.setter
-    def max_value(self, value):
-        self._max_value = value
+    @property
+    def device_limit_source(self) -> str | None:
+        """The authority ``device_limit`` comes from, or None if this entity has none."""
+        if self.battery_current_mirror_register is not None:
+            return "bms"
+        if self.max_source == MAX_SOURCE_INVERTER_RATING:
+            return MAX_SOURCE_INVERTER_RATING
+        return None
 
     def _bms_reported_max(self, mirror_register: int) -> float | None:
         """The mirror's value in amps, or None while it is absent/zero/unreadable."""
         try:
             raw = cache_get(self.hass, self.controller, mirror_register)
-        except Exception:  # no cache yet (tests, early setup) — fall back to the static max
+        except Exception:  # no cache yet (tests, early setup) — no advisory limit
             return None
         if not isinstance(raw, (int, float)) or isinstance(raw, bool) or raw <= 0:
             return None

--- a/custom_components/solis_modbus/sensors/solis_number_sensor.py
+++ b/custom_components/solis_modbus/sensors/solis_number_sensor.py
@@ -5,21 +5,10 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from custom_components.solis_modbus.const import CONTROLLER, REGISTER, SLAVE, VALUE
-from custom_components.solis_modbus.helpers import cache_get, is_correct_controller, register_update_signal
+from custom_components.solis_modbus.helpers import is_correct_controller, register_update_signal
 from custom_components.solis_modbus.sensors.solis_base_sensor import SolisBaseSensor
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def is_number(value) -> bool:
-    """Check if a value is a finite number (replaces removed homeassistant.helpers.template.is_number)."""
-    if isinstance(value, bool):
-        return False
-    try:
-        number = float(value)
-    except (ValueError, TypeError):
-        return False
-    return number == number and number not in (float("inf"), float("-inf"))
 
 
 class SolisNumberEntity(RestoreNumber, NumberEntity):
@@ -52,7 +41,11 @@ class SolisNumberEntity(RestoreNumber, NumberEntity):
         self._attr_native_value = sensor.default
         self._attr_mode = NumberMode.AUTO
         self._attr_native_min_value = sensor.min_value
-        # No _attr_native_max_value: the max is a property reading the base sensor live.
+        # Static by design: a declared max or the protocol ceiling, never a live device
+        # limit. HA rejects set_value above this, so a moving bound meant intermittent
+        # out_of_range failures and states above their own max (#464, #467). The live
+        # limit is advisory — see extra_state_attributes.
+        self._attr_native_max_value = sensor.max_value
 
         self._attr_native_step = sensor.step
         self._attr_step = sensor.step
@@ -61,10 +54,12 @@ class SolisNumberEntity(RestoreNumber, NumberEntity):
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
+        # Restore the *value* only. Restoring bounds from a snapshot is the same trap
+        # as deriving them live (#464/#467): a stale or momentary min/max/step comes
+        # back as a hard limit HA then enforces on writes.
         state = await self.async_get_last_number_data()
         if state:
             self._attr_native_value = state.native_value
-            # self.adjust_min_max_step(state.native_min_value, state.native_max_value, state.native_step)
 
         for reg in set(self._register):
             self.async_on_remove(
@@ -75,16 +70,16 @@ class SolisNumberEntity(RestoreNumber, NumberEntity):
                 )
             )
 
-        # Battery-current setpoints take their ceiling from a BMS mirror register that
-        # this entity doesn't otherwise read; follow it so the advertised max refreshes
-        # when the battery reports a new limit.
+        # Battery-current setpoints carry an advisory limit from a BMS mirror register
+        # that this entity doesn't otherwise read; follow it so the device_limit
+        # attribute refreshes when the battery reports a new limit.
         mirror = getattr(self.base_sensor, "battery_current_mirror_register", None)
         if isinstance(mirror, int):
             self.async_on_remove(
                 async_dispatcher_connect(
                     self._hass,
                     register_update_signal(self.base_sensor.controller, mirror),
-                    self.handle_max_mirror_update,
+                    self.handle_device_limit_update,
                 )
             )
 
@@ -92,38 +87,28 @@ class SolisNumberEntity(RestoreNumber, NumberEntity):
             self._attr_available = False
 
     @property
-    def native_max_value(self) -> float:
-        """Read the ceiling from the base sensor on every access.
+    def extra_state_attributes(self):
+        """Surface the live device limit next to the setpoint, without enforcing it.
 
-        ``RestoreNumber`` restores the *value*, not the bounds, and the BMS mirrors that
-        bound the battery-current setpoints land long after ``__init__`` — so the max
-        can't be a value frozen at construction.
+        Keeps "what may be configured" (the native min/max) and "what the device can
+        do right now" as the two different things they are (#464, #467): dashboards
+        and automations can read the limit here, while writes above it stay valid —
+        the device enforces its own limit at runtime.
         """
-        return self.base_sensor.max_value
+        source = self.base_sensor.device_limit_source
+        if source is None:
+            return None
+        return {
+            "device_limit": self.base_sensor.device_limit,
+            "device_limit_source": source,
+        }
 
     @callback
-    def handle_max_mirror_update(self, data):
-        """The BMS reported a new current limit — re-publish the bounds."""
+    def handle_device_limit_update(self, data):
+        """The BMS reported a new current limit — refresh the advisory attribute."""
         if not is_correct_controller(self.base_sensor.controller, str(data.get(CONTROLLER)), int(data.get(SLAVE))):
             return
         self.schedule_update_ha_state()
-
-    def adjust_min_max_step(self, min_wanted: float | None, max_wanted: float | None, step_wanted: float | None):
-        # float(43016) & equalization(43017) voltages, and rated capacity(43019)
-        if 43016 in self._register or 43017 in self._register or 43019 in self._register:
-            installed_battery = cache_get(self.hass, self.base_sensor.controller, 43009)
-
-            if is_number(installed_battery):
-                # only supported with a user defined battery
-                if installed_battery != 2 and not self.registry_entry.disabled:
-                    self.registry_entry.disabled = True
-                else:
-                    self.registry_entry.disabled = False
-
-        if self._attr_native_min_value != min_wanted and min_wanted is not None:
-            self._attr_native_min_value = min_wanted
-        if self._attr_native_step != step_wanted and step_wanted is not None:
-            self._attr_native_step = step_wanted
 
     @callback
     def handle_modbus_update(self, data):
@@ -166,6 +151,20 @@ class SolisNumberEntity(RestoreNumber, NumberEntity):
         # 🔹 Handle multi-register writing
         if self._write_register is None:
             return
+
+        # Advisory only — warn, never clamp or reject. Clamping would corrupt scheduled
+        # TOU config written while the BMS is derated (#467) and recreate the ratchet on
+        # firmware whose mirror echoes the setpoint (#464); the device enforces its real
+        # limit itself. abs(): signed dispatch registers are symmetric about zero.
+        limit = getattr(self.base_sensor, "device_limit", None)
+        if isinstance(limit, (int, float)) and not isinstance(limit, bool) and abs(value) > limit:
+            _LOGGER.warning(
+                "%s: requested %s exceeds the device's currently reported limit of %s (%s); writing anyway — the device enforces its own limit",
+                self._attr_name,
+                value,
+                limit,
+                self.base_sensor.device_limit_source,
+            )
 
         register_value = round(value / self._multiplier)
         if self.base_sensor.data_type == "S16":

--- a/tests/test_battery_current_max.py
+++ b/tests/test_battery_current_max.py
@@ -1,17 +1,21 @@
-"""Battery-current setpoints must not be hard-capped at 200 A.
+"""Battery-current setpoints: static bounds, advisory BMS limit.
 
-The four battery-current numbers (43012/43013 and 43117/43118) declared ``"max": 200``.
-That literal was dead for the entire life of the AMPERE derivation in ``adjust_max`` —
-the derivation overwrote it unconditionally — until the #438 fix made a declared max
-win. 200 A then became the effective ceiling for the first time, and Home Assistant
-started rejecting ``number.set_value`` above it with ``ServiceValidationError``, which
-also aborts any caller batching writes.
+Two generations of regressions meet here:
 
-200 A is not a protocol limit (U16 at 0.1 A carries 6553.5 A) and not a hardware one: a
-15 kW LV hybrid at 51.2 V needs ~293 A to reach its own nameplate. The battery already
-publishes its real limit on the mirrors 33206/33207, so that is what bounds these now.
+* ``"max": 200`` (and 135/300 on the TOU/time-charging currents) rejected legitimate
+  writes — a 15 kW LV hybrid at 51.2 V needs ~293 A, a parallel pair reports 580 A
+  (#351, #455). No literal survives contact with the fleet.
+* Replacing the literal with the live BMS mirror (33206/33207) made the bound *move*:
+  a real BMS derates with SOC, so the state ended up above its own max and automation
+  writes intermittently raised out_of_range (#467); on some firmware the mirror echoes
+  the setpoint back, so lowering the value ratcheted the max down one-way (#464).
+
+The resolution: the advertised max is the *static* protocol ceiling (what the register
+can carry — never wrong-low), and the mirror is surfaced as an advisory
+``device_limit`` attribute plus a log warning on write, never enforced.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -36,7 +40,7 @@ EXTENDED_DISCHARGE_REGISTERS = (43142, 43751, 43758, 43765, 43772, 43779, 43786)
 CHARGE_MIRROR = 33206
 DISCHARGE_MIRROR = 33207
 
-# U16 on a 0.1 A scale — the fallback once no rating-derived guess is allowed.
+# U16 on a 0.1 A scale — the static ceiling for every battery-current setpoint.
 PROTOCOL_CURRENT_MAX = 6553.5
 
 
@@ -82,7 +86,7 @@ class TestDefinitions:
     def test_no_declared_max_on_battery_current(self, register):
         entity = next(e for g in hybrid_sensors for e in g["entities"] if e.get("register") == [str(register)])
 
-        assert "max" not in entity, f"{entity['name']} declares a max; it must be resolved from the BMS mirror"
+        assert "max" not in entity, f"{entity['name']} declares a max; no literal survives contact with the fleet"
 
     @pytest.mark.parametrize("register", BATTERY_CURRENT_REGISTERS)
     def test_still_editable_with_a_min(self, register):
@@ -94,104 +98,126 @@ class TestDefinitions:
         assert entity["step"] == 0.1
 
 
-class TestMirrorDerivedMax:
+class TestTheAdvertisedMaxIsStatic:
+    """#464/#467: the bound must not track the mirror, whatever the mirror does."""
+
     def setup_method(self):
         self.hass = _Hass()
         self.controller = _controller(wattage_chosen=15000)
 
+    @pytest.mark.parametrize("register", BATTERY_CURRENT_REGISTERS)
+    def test_the_max_is_the_protocol_ceiling(self, register):
+        assert _sensor(self.hass, self.controller, register).max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
+
     @pytest.mark.parametrize("register", CHARGE_REGISTERS)
-    def test_charge_registers_follow_the_charge_mirror(self, register):
+    def test_a_derated_mirror_cannot_lower_the_max(self, register):
+        """#467: a Dyness HV at 12% SOC reports ~18 A — the bound must not follow."""
+        cache_save(self.hass, self.controller, CHARGE_MIRROR, 184)  # 18.4 A
+        sensor = _sensor(self.hass, self.controller, register)
+
+        assert sensor.max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
+
+    def test_a_setpoint_echo_cannot_ratchet_the_max(self):
+        """#464: firmware that mirrors the setpoint back must not shrink the range.
+
+        The reproduction: set 2 A, the mirror reports 2 A shortly after, and with the
+        old resolution the entity would never accept anything above 2 A again.
+        """
+        sensor = _sensor(self.hass, self.controller, 43117)
+        cache_save(self.hass, self.controller, CHARGE_MIRROR, 20)  # the echoed 2.0 A
+
+        assert sensor.max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
+        assert sensor.min_value <= 50 <= sensor.max_value  # raising it back stays valid
+
+    def test_a_580a_parallel_pair_stays_writable(self):
+        """#351: the case the mirror bound was built for still fits under the ceiling."""
+        sensor = _sensor(self.hass, self.controller, 43012)
+
+        assert sensor.min_value <= 580 <= sensor.max_value
+
+    @pytest.mark.parametrize("register", EXTENDED_CHARGE_REGISTERS + EXTENDED_DISCHARGE_REGISTERS)
+    def test_time_and_tou_currents_share_the_static_ceiling(self, register):
+        """Scheduled config (#467 point 2): the range must not depend on when you look."""
+        cache_save(self.hass, self.controller, CHARGE_MIRROR, 184)
+        cache_save(self.hass, self.controller, DISCHARGE_MIRROR, 184)
+
+        assert _sensor(self.hass, self.controller, register).max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
+
+
+class TestAdvisoryDeviceLimit:
+    """The mirror survives as information: device_limit, live, per direction."""
+
+    def setup_method(self):
+        self.hass = _Hass()
+        self.controller = _controller(wattage_chosen=15000)
+
+    @pytest.mark.parametrize("register", CHARGE_REGISTERS + EXTENDED_CHARGE_REGISTERS)
+    def test_charge_registers_report_the_charge_mirror(self, register):
         cache_save(self.hass, self.controller, CHARGE_MIRROR, 4000)  # 400.0 A
         sensor = _sensor(self.hass, self.controller, register)
 
-        assert sensor.max_value == 400.0
+        assert sensor.device_limit == 400.0
+        assert sensor.device_limit_source == "bms"
 
-    @pytest.mark.parametrize("register", DISCHARGE_REGISTERS)
-    def test_discharge_registers_follow_the_discharge_mirror(self, register):
+    @pytest.mark.parametrize("register", DISCHARGE_REGISTERS + EXTENDED_DISCHARGE_REGISTERS)
+    def test_discharge_registers_report_the_discharge_mirror(self, register):
         cache_save(self.hass, self.controller, DISCHARGE_MIRROR, 3500)  # 350.0 A
         sensor = _sensor(self.hass, self.controller, register)
 
-        assert sensor.max_value == 350.0
+        assert sensor.device_limit == 350.0
+        assert sensor.device_limit_source == "bms"
 
     def test_charge_and_discharge_mirrors_are_not_crossed(self):
         cache_save(self.hass, self.controller, CHARGE_MIRROR, 4000)
         cache_save(self.hass, self.controller, DISCHARGE_MIRROR, 1000)
 
-        assert _sensor(self.hass, self.controller, 43012).max_value == 400.0
-        assert _sensor(self.hass, self.controller, 43013).max_value == 100.0
+        assert _sensor(self.hass, self.controller, 43012).device_limit == 400.0
+        assert _sensor(self.hass, self.controller, 43013).device_limit == 100.0
 
-    def test_a_mirror_below_the_floor_is_not_widened(self):
-        """A BMS that reports 150 A means 150 A — the floor must not override it."""
-        cache_save(self.hass, self.controller, CHARGE_MIRROR, 1500)
-        sensor = _sensor(self.hass, self.controller, 43117)
-
-        assert sensor.max_value == 150.0
-
-    def test_the_mirror_is_read_live_not_frozen_at_construction(self):
+    def test_the_limit_is_read_live_not_frozen_at_construction(self):
         """Mirrors arrive asynchronously, long after the sensor was built."""
         sensor = _sensor(self.hass, self.controller, 43012)
-        derived = sensor.max_value
+        assert sensor.device_limit is None
 
         cache_save(self.hass, self.controller, CHARGE_MIRROR, 2930)
 
-        assert derived != 293.0
-        assert sensor.max_value == 293.0
+        assert sensor.device_limit == 293.0
 
     @pytest.mark.parametrize("absent", [None, 0])
-    def test_an_absent_or_zero_mirror_falls_back(self, absent):
+    def test_an_absent_or_zero_mirror_reports_no_limit(self, absent):
         """0 is 'not reported yet', not 'this battery accepts no current'."""
         if absent is not None:
             cache_save(self.hass, self.controller, CHARGE_MIRROR, absent)
-        sensor = _sensor(self.hass, self.controller, 43012)
 
-        assert sensor.max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
+        assert _sensor(self.hass, self.controller, 43012).device_limit is None
 
-    def test_a_hass_without_a_cache_falls_back(self):
+    def test_a_hass_without_a_cache_reports_no_limit(self):
         """Construction paths that pass hass=None must not explode."""
         sensor = _sensor(None, self.controller, 43012)
 
+        assert sensor.device_limit is None
         assert sensor.max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
 
+    def test_a_plain_register_has_no_limit_source(self):
+        sensor = SolisBaseSensor(
+            hass=self.hass,
+            controller=self.controller,
+            unique_id="u",
+            name="Backflow Power",
+            registrars=[43074],
+            write_register=43074,
+            multiplier=100,
+            unit_of_measurement=UnitOfPower.WATT,
+            editable=True,
+            max_value=20000,
+        )
 
-class TestDerivedFallback:
-    """Without a mirror the bound is the protocol ceiling, never the inverter rating.
-
-    A small AC rating says nothing about what a battery accepts, so it must not be able
-    to strand an install below what it could previously set.
-    """
-
-    def setup_method(self):
-        self.hass = _Hass()
-        self.controller = _controller(wattage_chosen=15000)
-
-    def test_a_small_rating_cannot_lower_the_bound(self):
-        """The old derivation gave round((3000/44)/10)*20 = 140 A here."""
-        sensor = _sensor(self.hass, _controller(wattage_chosen=3000), 43012)
-
-        assert sensor.max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
-
-    def test_the_rating_is_irrelevant_to_a_current_setpoint(self):
-        small = _sensor(self.hass, _controller(wattage_chosen=3000), 43117)
-        large = _sensor(self.hass, _controller(wattage_chosen=20000), 43117)
-
-        assert small.max_value == large.max_value
-
-    @pytest.mark.parametrize("register", EXTENDED_CHARGE_REGISTERS)
-    def test_time_and_tou_charge_currents_follow_the_charge_mirror(self, register):
-        """43141 and the six TOU charge slots are battery currents too (#351)."""
-        cache_save(self.hass, self.controller, CHARGE_MIRROR, 5800)  # 580.0 A
-
-        assert _sensor(self.hass, self.controller, register).max_value == 580.0
-
-    @pytest.mark.parametrize("register", EXTENDED_DISCHARGE_REGISTERS)
-    def test_time_and_tou_discharge_currents_follow_the_discharge_mirror(self, register):
-        cache_save(self.hass, self.controller, DISCHARGE_MIRROR, 5800)
-
-        assert _sensor(self.hass, self.controller, register).max_value == 580.0
+        assert sensor.device_limit is None
+        assert sensor.device_limit_source is None
 
 
 class TestIssue438DoesNotRegress:
-    """Declared maxima on grid registers still win over the inverter rating."""
+    """Declared maxima on grid registers still win over everything derived."""
 
     def setup_method(self):
         self.hass = _Hass()
@@ -214,35 +240,38 @@ class TestIssue438DoesNotRegress:
 
         assert sensor.max_value == declared
 
-    def test_a_declared_max_on_a_battery_register_still_loses_to_the_bms(self):
-        """The mirror is the authority for these four, declared or not."""
-        cache_save(self.hass, self.controller, CHARGE_MIRROR, 4000)
-        sensor = _sensor(self.hass, self.controller, 43012, max_value=200)
-
-        assert sensor.max_value == 400.0
-
 
 @pytest.mark.asyncio
-class TestNumberEntityAdvertisesTheLiveMax:
-    async def test_the_entity_reports_the_mirror(self, hass):
+class TestNumberEntity:
+    async def test_the_entity_advertises_the_static_ceiling(self, hass):
+        """#467: an 18.4 A mirror must not become the entity's max."""
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        cache_save(hass, controller, CHARGE_MIRROR, 184)
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+
+        assert entity.native_max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
+
+    async def test_the_entity_surfaces_the_limit_as_an_attribute(self, hass):
         hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
         controller = _controller(wattage_chosen=15000)
         cache_save(hass, controller, CHARGE_MIRROR, 2930)
         entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
 
-        assert entity.native_max_value == 293.0
+        assert entity.extra_state_attributes == {"device_limit": 293.0, "device_limit_source": "bms"}
 
-    async def test_the_entity_max_tracks_a_later_mirror_update(self, hass):
-        """The reported bound moves without the entity being rebuilt."""
+    async def test_the_attribute_tracks_a_later_mirror_update(self, hass):
+        """The advisory limit moves without the entity being rebuilt."""
         hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
         controller = _controller(wattage_chosen=15000)
         entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+        assert entity.extra_state_attributes["device_limit"] is None
 
         cache_save(hass, controller, CHARGE_MIRROR, 2930)
 
-        assert entity.native_max_value == 293.0
+        assert entity.extra_state_attributes["device_limit"] == 293.0
 
-    async def test_a_mirror_arriving_republishes_the_bounds(self, hass):
+    async def test_a_mirror_arriving_republishes_the_attributes(self, hass):
         """The mirror isn't one of the entity's own registers — it must still wake it."""
         hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
         controller = _controller(wattage_chosen=15000)
@@ -258,7 +287,7 @@ class TestNumberEntityAdvertisesTheLiveMax:
         entity.schedule_update_ha_state.assert_called()
 
     async def test_another_inverters_mirror_is_ignored(self, hass):
-        """Two inverters on one logger must not rewrite each other's bounds."""
+        """Two inverters on one logger must not rewrite each other's attributes."""
         hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
         controller = _controller(wattage_chosen=15000)
         entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
@@ -280,7 +309,6 @@ class TestNumberEntityAdvertisesTheLiveMax:
         """RestoreNumber restores the value; a stale 200 A bound must not come back."""
         hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
         controller = _controller(wattage_chosen=15000)
-        cache_save(hass, controller, CHARGE_MIRROR, 2930)
         entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
         entity.hass = hass
         entity.entity_id = "number.battery_max_charge_current"
@@ -292,10 +320,10 @@ class TestNumberEntityAdvertisesTheLiveMax:
         await entity.async_added_to_hass()
 
         assert entity.native_value == 100.0
-        assert entity.native_max_value == 293.0
+        assert entity.native_max_value == pytest.approx(PROTOCOL_CURRENT_MAX)
 
     async def test_293a_is_writable_on_a_15kw_lv_hybrid(self, hass):
-        """The reproduction: set_value 293 used to raise before reaching us."""
+        """The #455 reproduction: set_value 293 used to raise before reaching us."""
         hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
         controller = _controller(wattage_chosen=15000)
         cache_save(hass, controller, CHARGE_MIRROR, 3000)
@@ -309,3 +337,34 @@ class TestNumberEntityAdvertisesTheLiveMax:
 
         # 0.1 A scale: 293 A on the wire is 2930.
         controller.async_write_holding_register.assert_called_with(43117, 2930)
+
+    async def test_a_write_above_a_derated_limit_goes_through_with_a_warning(self, hass, caplog):
+        """#467 (Valiante): 60 A into a momentarily derated pack must not raise."""
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        cache_save(hass, controller, CHARGE_MIRROR, 184)  # BMS says 18.4 A right now
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43141))
+        entity.schedule_update_ha_state = MagicMock()
+
+        assert entity.native_min_value <= 60 <= entity.native_max_value
+
+        with caplog.at_level(logging.WARNING):
+            entity.set_native_value(60)
+        await hass.async_block_till_done()
+
+        controller.async_write_holding_register.assert_called_with(43141, 600)
+        assert any("18.4" in r.getMessage() for r in caplog.records)
+
+    async def test_a_write_within_the_limit_does_not_warn(self, hass, caplog):
+        hass.data.setdefault(DOMAIN, {}).setdefault(VALUES, {})
+        controller = _controller(wattage_chosen=15000)
+        cache_save(hass, controller, CHARGE_MIRROR, 3000)
+        entity = SolisNumberEntity(hass, _sensor(hass, controller, 43117))
+        entity.schedule_update_ha_state = MagicMock()
+
+        with caplog.at_level(logging.WARNING):
+            entity.set_native_value(50)
+        await hass.async_block_till_done()
+
+        controller.async_write_holding_register.assert_called_with(43117, 500)
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]

--- a/tests/test_max_bounds_integrity.py
+++ b/tests/test_max_bounds_integrity.py
@@ -118,6 +118,16 @@ def test_the_rating_is_only_ever_an_opt_in(entity):
 NEGATIVE_MIN_MARKERS = [e for e in ENTITIES if e.get("min", 0) < 0 and e.get("max") is None]
 
 
+def test_the_signed_marker_registers_still_exist():
+    """An empty list would make the parametrized contract test below vanish silently.
+
+    If a definition change legitimately removes the last negative-min marker (e.g. by
+    declaring a max on 43128/43133/43134), this failure forces a conscious update
+    here rather than a quiet loss of coverage.
+    """
+    assert NEGATIVE_MIN_MARKERS, "no negative-min marker entities left — update or remove the marker contract tests"
+
+
 @pytest.mark.parametrize("entity", NEGATIVE_MIN_MARKERS, ids=[e["register"][0] for e in NEGATIVE_MIN_MARKERS])
 def test_a_negative_min_without_a_declared_max_is_only_a_marker(entity):
     """The literal's value must never survive as the bound — only its sign is read.

--- a/tests/test_max_bounds_integrity.py
+++ b/tests/test_max_bounds_integrity.py
@@ -4,11 +4,17 @@
 inverter's AC rating, applied to every editable entity because it was keyed off the unit.
 A change aimed at one register silently retargeted all of them.
 
+#464 and #467 then showed the inverse failure: an *authoritative* bound that moves (the
+BMS mirror derating with SOC, or echoing the setpoint back) rejects legitimate writes
+and strands states above their own max. So authorities don't set bounds either — they
+are surfaced as an advisory ``device_limit``.
+
 These tests lock the resolution order in place rather than the individual numbers:
 
 1. a declared ``"max"`` must be a value the register can actually carry;
-2. omitting ``"max"`` must never produce a rating-derived ceiling;
-3. only an explicit ``"max_source"`` reaches ``wattage_chosen``.
+2. omitting ``"max"`` resolves to the protocol ceiling — never a rating-derived one;
+3. only an explicit ``"max_source"`` reaches ``wattage_chosen``, and only as the
+   advisory ``device_limit``, never as the advertised max.
 """
 
 import pytest
@@ -109,6 +115,35 @@ def test_the_rating_is_only_ever_an_opt_in(entity):
     assert source in (None, MAX_SOURCE_INVERTER_RATING), f"unknown max_source {source!r}"
 
 
+NEGATIVE_MIN_MARKERS = [e for e in ENTITIES if e.get("min", 0) < 0 and e.get("max") is None]
+
+
+@pytest.mark.parametrize("entity", NEGATIVE_MIN_MARKERS, ids=[e["register"][0] for e in NEGATIVE_MIN_MARKERS])
+def test_a_negative_min_without_a_declared_max_is_only_a_marker(entity):
+    """The literal's value must never survive as the bound — only its sign is read.
+
+    With no declared max the floor resolves to the protocol floor, whatever number
+    the marker happens to be (43128/43133/43134 ship -10000 for historical reasons).
+    """
+    sensor = _build(entity, _controller())
+
+    assert sensor.min_value == sensor.protocol_min
+    assert sensor.min_value != entity["min"]
+
+
+def test_a_fully_declared_signed_range_is_not_widened():
+    """Export Calibration (43195) declares both bounds — the ±1000 trim survives.
+
+    The protocol floor only replaces a negative min when the ceiling was derived;
+    a definition that declares its max keeps its declared min untouched.
+    """
+    entity = next(e for e in ENTITIES if e["register"] == ["43195"])
+    sensor = _build(entity, _controller())
+
+    assert sensor.max_value == 1000
+    assert sensor.min_value == -1000
+
+
 def test_every_data_type_has_a_range():
     """A new DataType without a range would silently fall back to U16."""
     from custom_components.solis_modbus.data.enums import DataType
@@ -181,19 +216,38 @@ class TestHvBatteryVoltages:
 
 
 class TestIssue351:
-    """RC force charge/discharge must reach the inverter's own nameplate."""
+    """RC force charge/discharge must reach the inverter's own nameplate — and beyond.
+
+    The rating is not the advertised max (that would reject a legitimate DC-side
+    setpoint or a misconfigured model's dispatch, the #464/#467 failure mode); it is
+    the advisory ``device_limit``, and the bound is the protocol ceiling.
+    """
 
     @pytest.mark.parametrize("register", [43027, 43129, 43130, 43131, 43136])
     def test_a_20kw_inverter_can_dispatch_20kw(self, register):
         entity = next(e for e in ENTITIES if e["register"] == [str(register)])
         sensor = _build(entity, _controller(wattage_chosen=20000))
 
-        assert sensor.max_value == 20000
+        assert sensor.min_value <= 20000 <= sensor.max_value
+        assert sensor.device_limit == 20000
+        assert sensor.device_limit_source == MAX_SOURCE_INVERTER_RATING
+
+    @pytest.mark.parametrize("register", [43027, 43129, 43130, 43131, 43136])
+    def test_the_rating_does_not_cap_the_advertised_max(self, register):
+        """A wrong-low rating must not turn into hard write rejections."""
+        entity = next(e for e in ENTITIES if e["register"] == [str(register)])
+        sensor = _build(entity, _controller(wattage_chosen=3000))
+
+        assert sensor.max_value == sensor.protocol_max
+        assert sensor.device_limit == 3000
 
     @pytest.mark.parametrize("register", [43128, 43133, 43134])
-    def test_signed_dispatch_registers_stay_symmetric(self, register):
+    def test_signed_dispatch_registers_open_the_full_signed_range(self, register):
+        """The floor resolves like the ceiling — the protocol range, opposite direction."""
         entity = next(e for e in ENTITIES if e["register"] == [str(register)])
         sensor = _build(entity, _controller(wattage_chosen=20000))
 
-        assert sensor.max_value == 20000
-        assert sensor.min_value == -20000
+        assert sensor.max_value == sensor.protocol_max
+        assert sensor.min_value == sensor.protocol_min
+        assert sensor.min_value < 0
+        assert sensor.device_limit == 20000

--- a/tests/test_max_value_declaration.py
+++ b/tests/test_max_value_declaration.py
@@ -159,12 +159,17 @@ class TestUndeclaredMaxUsesProtocolCeiling(unittest.TestCase):
 
 
 class TestInverterRatingIsOptIn(unittest.TestCase):
-    """``wattage_chosen`` is only reachable through an explicit "max_source"."""
+    """``wattage_chosen`` is only reachable through an explicit "max_source".
+
+    And even then it is the advisory ``device_limit``, never the advertised max:
+    a wrong-low rating as a bound would make HA reject legitimate dispatch writes —
+    the #464/#467 failure mode, on the RC path.
+    """
 
     def setUp(self):
         self.controller = MockController(wattage_chosen=20000)
 
-    def test_declared_source_uses_the_rating(self):
+    def test_declared_source_reports_the_rating_as_the_device_limit(self):
         sensor = _group(
             self.controller,
             {
@@ -177,10 +182,14 @@ class TestInverterRatingIsOptIn(unittest.TestCase):
                 "max_source": "inverter_rating",
             },
         ).sensors[0]
-        self.assertEqual(sensor.max_value, 20000)
+        self.assertEqual(sensor.device_limit, 20000)
+        self.assertEqual(sensor.device_limit_source, "inverter_rating")
+        # The advertised bound stays at the protocol ceiling.
+        self.assertEqual(sensor.max_value, 65535 * 10)
 
-    def test_a_signed_source_register_is_symmetric(self):
-        """43128 must be able to export as far as it can import."""
+    def test_a_signed_source_register_opens_the_full_signed_range(self):
+        """43128 must be able to export as far as it can import: the floor is the
+        protocol floor, resolved by the same rule as the ceiling."""
         sensor = _group(
             self.controller,
             {
@@ -194,11 +203,12 @@ class TestInverterRatingIsOptIn(unittest.TestCase):
                 "max_source": "inverter_rating",
             },
         ).sensors[0]
-        self.assertEqual(sensor.max_value, 20000)
-        self.assertEqual(sensor.min_value, -20000)
+        self.assertEqual(sensor.max_value, 32767 * 10)
+        self.assertEqual(sensor.min_value, -32768 * 10)
+        self.assertEqual(sensor.device_limit, 20000)
 
-    def test_an_unusable_rating_falls_back_to_the_protocol_ceiling(self):
-        """Never wrong-low: a missing rating must not collapse the bound."""
+    def test_an_unusable_rating_reports_no_device_limit(self):
+        """A missing rating must not invent an advisory limit."""
         sensor = _group(
             MockController(wattage_chosen=0),
             {
@@ -211,6 +221,7 @@ class TestInverterRatingIsOptIn(unittest.TestCase):
                 "max_source": "inverter_rating",
             },
         ).sensors[0]
+        self.assertIsNone(sensor.device_limit)
         self.assertEqual(sensor.max_value, 65535 * 10)
 
     def test_a_kilowatt_source_register_scales_the_rating(self):
@@ -225,7 +236,7 @@ class TestInverterRatingIsOptIn(unittest.TestCase):
                 "max_source": "inverter_rating",
             },
         ).sensors[0]
-        self.assertEqual(sensor.max_value, 20)
+        self.assertEqual(sensor.device_limit, 20)
 
 
 class TestInverterWattageCatalogue(unittest.TestCase):


### PR DESCRIPTION
### **User description**
## 🔄 Related Issues
Closes #464 #467 

## ✅ Testing Steps
1. **Tested With**: [e.g., Solis 5G 6kW, Axitec 10kW]
2. **Test Results**: [e.g., Switches update correctly, no errors]

## ➕ Additional Notes
Editable number entities no longer take their advertised min/max from live or derived device data — bounds are now static: a declared (audited) literal, else the protocol range the register can physically carry. The live limits survive as an advisory device_limit/device_limit_source attribute on each entity, refreshed as the BMS reports, with a log warning (never a clamp or reject) when a write exceeds it.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Keep editable bounds at static protocol ranges

- Expose live BMS and inverter limits advisory

- Warn without blocking writes above device limits

- Cover current, TOU, and dispatch regressions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  limits["Live BMS and inverter limits"]
  attributes["Advisory entity attributes"]
  bounds["Static protocol bounds"]
  writes["Editable number writes"]
  warning["Warning above device limit"]
  device["Device runtime enforcement"]
  limits -- "published as" --> attributes
  bounds -- "validate configuration" --> writes
  attributes -- "checked during write" --> warning
  warning -- "allows write" --> device
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid_sensors.py</strong><dd><code>Document protocol bounds across editable hybrid settings</code>&nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensor_data/hybrid_sensors.py

<ul><li>Clarifies protocol ceilings for battery currents<br> <li> Marks BMS and inverter limits advisory<br> <li> Documents signed dispatch protocol-range behavior<br> <li> Covers TOU, charging, and remote-control settings</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/471/files#diff-540e84e48ae8dd4a164fe7fa970bf88a7375c29588090e2cfe4b8bf7ff16518f">+70/-47</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_base_sensor.py</strong><dd><code>Separate static bounds from advisory device limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_base_sensor.py

<ul><li>Resolves undeclared maxima from protocol ranges<br> <li> Resolves signed floors from protocol minima<br> <li> Exposes live limits and their sources<br> <li> Separates configuration bounds from runtime capability</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/471/files#diff-860eca3794a5fe17bc0ebb1c0fbd3e8200567a092f4fd861ae1f4565ec30455a">+72/-57</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>solis_number_sensor.py</strong><dd><code>Surface device limits without blocking number writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/solis_modbus/sensors/solis_number_sensor.py

<ul><li>Advertises static native number bounds<br> <li> Publishes <code>device_limit</code> and <code>device_limit_source</code> attributes<br> <li> Refreshes attributes when BMS mirrors update<br> <li> Warns but permits writes exceeding live limits</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/471/files#diff-12de5d2a79db4982e540517bacb61591ae1560a31897d2b123b51a5be1cd2b24">+42/-43</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_battery_current_max.py</strong><dd><code>Test static battery bounds and advisory limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_battery_current_max.py

<ul><li>Verifies battery-current bounds remain protocol-based<br> <li> Tests live BMS limits as attributes<br> <li> Covers SOC derating and setpoint ratcheting<br> <li> Confirms above-limit writes warn and proceed</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/471/files#diff-6d3849fb0c90fcebd34eb219d6a7c6c5fabc55029834cf62c276985e70bec485">+149/-90</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_max_bounds_integrity.py</strong><dd><code>Strengthen editable bound integrity regression coverage</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_max_bounds_integrity.py

<ul><li>Validates protocol ceilings and signed floors<br> <li> Ensures inverter ratings remain advisory<br> <li> Preserves explicitly declared signed ranges<br> <li> Covers remote-control dispatch above device ratings</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/471/files#diff-561f2d81264bbe456228d5c4c93283874b48b573fd6f317dd98de2af43c8380b">+61/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_max_value_declaration.py</strong><dd><code>Update maximum resolution and rating source tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_max_value_declaration.py

<ul><li>Tests rating-derived advisory device limits<br> <li> Confirms protocol bounds remain advertised<br> <li> Verifies full signed register ranges<br> <li> Handles missing and unit-scaled inverter ratings</ul>


</details>


  </td>
  <td><a href="https://github.com/Pho3niX90/solis_modbus/pull/471/files#diff-00dbad5ced9ea065d3b4d9ca7ccfd934554ed2e41276e3167509b7a2b271e58a">+21/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Battery-current and time-of-use charge/discharge controls now use protocol-defined operating ranges.
  * Device ratings and live BMS readings are shown as advisory limits rather than hard restrictions.
  * Signed controls retain their full supported negative and positive ranges.
  * Number controls display current device-limit information and update it dynamically.
  * Values above advisory limits remain writable, with a warning shown instead of automatic rejection or clamping.
* **Bug Fixes**
  * Restored settings no longer reinstate outdated dynamic limits.
  * Unavailable or zero device-limit readings no longer incorrectly restrict controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->